### PR TITLE
Feat/search web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ AGENTS.md
 .mcp.json
 .continuerules
 *.json.*
+.codex
 
 # Dirs
 Chrome.bak/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Local AI - Changelog
 
-## [1.29.28] - 2026-03-27 - latest
+## [1.29.30] - 2026-03-29 - latest
+
+### Browser-Session Web Search
+
+- Added `search_web` internal tool allowing the LLM to search the web using the user's configured search engine
+- Search opens a reusable background tab (visible, non-active) and reuses it across requests — tab ID persisted in `chrome.storage.session`
+- Added `src/jslib/search-engines.js` — engine registry with URL builders, SERP CSS selectors, and URL filters/decoders for DuckDuckGo, Google, and Bing
+- Added `src/jslib/web-search.js` — orchestrator handling tab lifecycle, SERP scraping via `chrome.scripting.executeScript`, result page content extraction, captcha/consent detection, and result assembly
+- Added `searchEngine` setting (default: DuckDuckGo) and `searchResultCount` setting (default: 3, max: 5) to General Settings
+- Fixed `saveSettings` in options page not persisting plain `<select>` values (`select-one` type was missing from the handled types list)
+
+## [1.29.28] - 2026-03-27
 
 ### Bug Fixes
 

--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Local AI helper",
     "short_name": "localAI",
-    "version": "1.29.28",
+    "version": "1.29.30",
     "options_page": "options.html",
     "permissions": [
         "activeTab",

--- a/Firefox/manifest.json
+++ b/Firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local AI helper",
-  "version": "1.29.28",
+  "version": "1.29.30",
   "options_page": "options.html",
   "permissions": [
     "activeTab",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you value privacy but still want the power of LLMs, LocalAI is for you. There
 
 * **Local Control:** Your data stays on your device—no sharing or storing of your actions. You control what to keep or delete.
 * **Task Assistance:** Need summaries or quick insights? LocalAI helps with tasks using the information in your active tab.
+* **Web Search:** Ask the AI to search the web and it will use your configured search engine in a background tab — no external APIs, no credential sharing.
 * **Custom Prompts:** Create, store, and execute your own prompts locally for a personalised experience.
 * **External Hooks:** Enhance functionality by integrating your own solutions and resources.
 

--- a/src/background.js
+++ b/src/background.js
@@ -44,6 +44,18 @@ try {
     console.error('>>> Failed to load jslib/internal-tools.js:', e);
 }
 
+try {
+    importScripts('jslib/search-engines.js');
+} catch (e) {
+    console.error('>>> Failed to load jslib/search-engines.js:', e);
+}
+
+try {
+    importScripts('jslib/web-search.js');
+} catch (e) {
+    console.error('>>> Failed to load jslib/web-search.js:', e);
+}
+
 init();
 clearLegacyPageContentStorage();
 

--- a/src/jslib/constants.js
+++ b/src/jslib/constants.js
@@ -13,3 +13,5 @@ var MAX_SESSION_PAGES = 5; // Maximum pages to keep per session
 var ARCHIVE_RETENTION_DAYS = 2; // Keep archived sessions for 2 days
 var mainHelpPageUrl = 'https://github.com/ivostoykov/localAI/blob/main/documentation.md';
 var modifiersHelpUrl = 'https://github.com/ivostoykov/localAI/blob/main/documentation.md#modifiers';
+var DEFAULT_SEARCH_ENGINE = 'duckduckgo';
+var DEFAULT_SEARCH_RESULT_COUNT = 3;

--- a/src/jslib/internal-tools.js
+++ b/src/jslib/internal-tools.js
@@ -244,6 +244,9 @@ async function execInternalTool(call = {}, tabId = null) {
 
         case "get_main_content":
             return await callContentScriptExtractor(tabId, 'getMainContentOnly', null);
+
+        case "search_web":
+            return await searchWeb(call?.function?.arguments?.query);
     }
 }
 
@@ -585,6 +588,25 @@ const INTERNAL_TOOL_DEFINITIONS = [
         "strict": true,
         "type": "tool",
         "usage_cost": 3
+    },
+    {
+        "function": {
+            "description": "Search the web using the user's configured search engine. Opens a background browser tab, fetches the search results page, and returns extracted content from the top result pages. Use when the user explicitly asks to search the web, look something up online, or find information not available on the current page. Do NOT use for current page content — use get_current_tab_page_content instead.",
+            "name": "search_web",
+            "parameters": {
+                "properties": {
+                    "query": {
+                        "description": "The search query",
+                        "type": "string"
+                    }
+                },
+                "required": ["query"],
+                "type": "object"
+            }
+        },
+        "strict": true,
+        "type": "tool",
+        "usage_cost": 5
     },
     {
         "function": {

--- a/src/jslib/search-engines.js
+++ b/src/jslib/search-engines.js
@@ -1,0 +1,69 @@
+/**
+ * Search Engines Module
+ * Engine configurations and SERP result selectors for browser-session web search.
+ * Pure module — no browser API dependency.
+ */
+
+const ENGINES = {
+    duckduckgo: {
+        name: 'DuckDuckGo',
+        buildUrl: (query) => `https://duckduckgo.com/?q=${encodeURIComponent(query)}&ia=web`,
+        resultSelectors: [
+            'a[data-testid="result-title-a"]',
+            'a.result__a',
+            'h2.result__title a'
+        ],
+        filterUrl: (url) => !url.includes('duckduckgo.com') && url.startsWith('http')
+    },
+    google: {
+        name: 'Google',
+        buildUrl: (query) => `https://www.google.com/search?q=${encodeURIComponent(query)}`,
+        resultSelectors: [
+            'div#search a[jsname][href^="http"]',
+            'div.g a[href^="http"]'
+        ],
+        filterUrl: (url) => {
+            try {
+                const u = new URL(url);
+                return !u.hostname.endsWith('google.com') && !u.hostname.endsWith('googleapis.com');
+            } catch {
+                return false;
+            }
+        },
+        decodeUrl: (url) => {
+            try {
+                const u = new URL(url);
+                if (u.pathname === '/url') {
+                    const decoded = u.searchParams.get('q');
+                    if (decoded && decoded.startsWith('http')) return decoded;
+                }
+            } catch { /* ignore */ }
+            return url;
+        }
+    },
+    bing: {
+        name: 'Bing',
+        buildUrl: (query) => `https://www.bing.com/search?q=${encodeURIComponent(query)}`,
+        resultSelectors: [
+            'li.b_algo h2 a',
+            'ol#b_results li.b_algo a[href^="http"]'
+        ],
+        filterUrl: (url) => {
+            try {
+                const u = new URL(url);
+                return !u.hostname.endsWith('bing.com') && !u.hostname.endsWith('microsoft.com');
+            } catch {
+                return false;
+            }
+        }
+    }
+};
+
+function getSearchUrl(engine, query) {
+    const eng = ENGINES[engine] ?? ENGINES.duckduckgo;
+    return eng.buildUrl(query);
+}
+
+function getEngineConfig(engine) {
+    return ENGINES[engine] ?? ENGINES.duckduckgo;
+}

--- a/src/jslib/search-engines.js
+++ b/src/jslib/search-engines.js
@@ -19,8 +19,8 @@ const ENGINES = {
         name: 'Google',
         buildUrl: (query) => `https://www.google.com/search?q=${encodeURIComponent(query)}`,
         resultSelectors: [
-            'div#search h3 a[href^="http"]',
-            'div.g h3 a[href^="http"]'
+            'div#search a:has(h3)[href^="http"]',
+            'div.g a:has(h3)[href^="http"]'
         ],
         filterUrl: (url) => {
             try {

--- a/src/jslib/search-engines.js
+++ b/src/jslib/search-engines.js
@@ -19,8 +19,8 @@ const ENGINES = {
         name: 'Google',
         buildUrl: (query) => `https://www.google.com/search?q=${encodeURIComponent(query)}`,
         resultSelectors: [
-            'div#search a[jsname][href^="http"]',
-            'div.g a[href^="http"]'
+            'div#search h3 a[href^="http"]',
+            'div.g h3 a[href^="http"]'
         ],
         filterUrl: (url) => {
             try {
@@ -45,8 +45,7 @@ const ENGINES = {
         name: 'Bing',
         buildUrl: (query) => `https://www.bing.com/search?q=${encodeURIComponent(query)}`,
         resultSelectors: [
-            'li.b_algo h2 a',
-            'ol#b_results li.b_algo a[href^="http"]'
+            'li.b_algo h2 a'
         ],
         filterUrl: (url) => {
             try {

--- a/src/jslib/web-search.js
+++ b/src/jslib/web-search.js
@@ -52,24 +52,25 @@ async function extractSerpUrls(searchTabId, engine, maxResults) {
     try {
         scriptResult = await chrome.scripting.executeScript({
             target: { tabId: searchTabId },
-            func: (selectors) => {
+            func: (selectors, limit) => {
                 const seen = new Set();
                 const links = [];
                 for (const sel of selectors) {
+                    if (links.length >= limit) break;
                     try {
-                        document.querySelectorAll(sel).forEach(el => {
-                            const anchor = el.tagName === 'A' ? el : el.closest('a');
-                            const href = anchor?.href;
+                        for (const el of document.querySelectorAll(sel)) {
+                            if (links.length >= limit) break;
+                            const href = el.href;
                             if (href && href.startsWith('http') && !seen.has(href)) {
                                 seen.add(href);
                                 links.push(href);
                             }
-                        });
+                        }
                     } catch { /* ignore invalid selectors */ }
                 }
                 return links;
             },
-            args: [config.resultSelectors]
+            args: [config.resultSelectors, maxResults]
         });
     } catch (err) {
         console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - extractSerpUrls failed:`, err);

--- a/src/jslib/web-search.js
+++ b/src/jslib/web-search.js
@@ -107,14 +107,16 @@ async function isCaptchaOrConsentPage(tabId) {
 async function fetchPageSummary(searchTabId, url) {
     console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Fetching page summary:`, url);
     try {
+        const loadPromise = waitForTabLoad(searchTabId);
         await chrome.tabs.update(searchTabId, { url });
-        await waitForTabLoad(searchTabId);
+        await loadPromise;
         const response = await chrome.tabs.sendMessage(searchTabId, {
             action: 'callContentExtractor',
             functionName: 'getMainContentOnly',
             argument: null
         });
-        const content = response?.error ? '' : (response?.result || '');
+        const raw = response?.error ? '' : (response?.result || '');
+        const content = raw.startsWith('Could not detect') ? '' : raw;
         return { url, content };
     } catch (err) {
         console.warn(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - fetchPageSummary failed for ${url}:`, err.message);
@@ -143,8 +145,9 @@ async function searchWeb(query) {
 
     const serpUrl = getSearchUrl(engine, query);
     try {
+        const loadPromise = waitForTabLoad(searchTabId);
         await chrome.tabs.update(searchTabId, { url: serpUrl });
-        await waitForTabLoad(searchTabId);
+        await loadPromise;
     } catch (err) {
         return `Search failed: could not load results page. ${err.message}`;
     }

--- a/src/jslib/web-search.js
+++ b/src/jslib/web-search.js
@@ -1,0 +1,177 @@
+/**
+ * Web Search Module
+ * Orchestrates browser-session web search using a reusable background tab.
+ * Runs in the background service worker context.
+ */
+
+const SEARCH_TAB_KEY = 'searchTabId';
+
+async function getOrCreateSearchTab() {
+    const stored = await chrome.storage.session.get(SEARCH_TAB_KEY);
+    const storedId = stored[SEARCH_TAB_KEY];
+
+    if (storedId) {
+        try {
+            await chrome.tabs.get(storedId);
+            console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Reusing search tab`, storedId);
+            return storedId;
+        } catch {
+            // Tab no longer exists — fall through to create a new one
+        }
+    }
+
+    const tab = await chrome.tabs.create({ active: false, url: 'about:blank' });
+    await chrome.storage.session.set({ [SEARCH_TAB_KEY]: tab.id });
+    console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Created search tab`, tab.id);
+    return tab.id;
+}
+
+function waitForTabLoad(tabId, timeoutMs = 20000) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            chrome.tabs.onUpdated.removeListener(listener);
+            reject(new Error('Tab load timed out'));
+        }, timeoutMs);
+
+        function listener(updatedTabId, changeInfo) {
+            if (updatedTabId === tabId && changeInfo.status === 'complete') {
+                clearTimeout(timer);
+                chrome.tabs.onUpdated.removeListener(listener);
+                resolve();
+            }
+        }
+
+        chrome.tabs.onUpdated.addListener(listener);
+    });
+}
+
+async function extractSerpUrls(searchTabId, engine, maxResults) {
+    const config = getEngineConfig(engine);
+
+    let scriptResult;
+    try {
+        scriptResult = await chrome.scripting.executeScript({
+            target: { tabId: searchTabId },
+            func: (selectors) => {
+                const seen = new Set();
+                const links = [];
+                for (const sel of selectors) {
+                    try {
+                        document.querySelectorAll(sel).forEach(el => {
+                            const anchor = el.tagName === 'A' ? el : el.closest('a');
+                            const href = anchor?.href;
+                            if (href && href.startsWith('http') && !seen.has(href)) {
+                                seen.add(href);
+                                links.push(href);
+                            }
+                        });
+                    } catch { /* ignore invalid selectors */ }
+                }
+                return links;
+            },
+            args: [config.resultSelectors]
+        });
+    } catch (err) {
+        console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - extractSerpUrls failed:`, err);
+        return [];
+    }
+
+    let urls = scriptResult?.[0]?.result || [];
+
+    if (config.decodeUrl) {
+        urls = urls.map(config.decodeUrl);
+    }
+
+    if (config.filterUrl) {
+        urls = urls.filter(config.filterUrl);
+    }
+
+    const result = [...new Set(urls)].slice(0, maxResults);
+    console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - SERP URLs extracted (${result.length}):`, result);
+    return result;
+}
+
+async function isCaptchaOrConsentPage(tabId) {
+    try {
+        const results = await chrome.scripting.executeScript({
+            target: { tabId },
+            func: () => document.title.toLowerCase()
+        });
+        const title = results?.[0]?.result || '';
+        return /captcha|verify|consent|blocked|unusual traffic|robot/i.test(title);
+    } catch {
+        return false;
+    }
+}
+
+async function fetchPageSummary(searchTabId, url) {
+    console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Fetching page summary:`, url);
+    try {
+        await chrome.tabs.update(searchTabId, { url });
+        await waitForTabLoad(searchTabId);
+        const response = await chrome.tabs.sendMessage(searchTabId, {
+            action: 'callContentExtractor',
+            functionName: 'getMainContentOnly',
+            argument: null
+        });
+        const content = response?.error ? '' : (response?.result || '');
+        return { url, content };
+    } catch (err) {
+        console.warn(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - fetchPageSummary failed for ${url}:`, err.message);
+        return { url, content: '' };
+    }
+}
+
+async function searchWeb(query) {
+    if (!query?.trim()) {
+        return 'No search query provided.';
+    }
+
+    const stored = await chrome.storage.sync.get('laiOptions');
+    const opts = stored.laiOptions || {};
+    const engine = opts.searchEngine || DEFAULT_SEARCH_ENGINE;
+    const maxResults = Math.min(Number(opts.searchResultCount) || DEFAULT_SEARCH_RESULT_COUNT, 5);
+
+    console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - searchWeb:`, { query, engine, maxResults });
+
+    let searchTabId;
+    try {
+        searchTabId = await getOrCreateSearchTab();
+    } catch (err) {
+        return `Search failed: could not create search tab. ${err.message}`;
+    }
+
+    const serpUrl = getSearchUrl(engine, query);
+    try {
+        await chrome.tabs.update(searchTabId, { url: serpUrl });
+        await waitForTabLoad(searchTabId);
+    } catch (err) {
+        return `Search failed: could not load results page. ${err.message}`;
+    }
+
+    if (await isCaptchaOrConsentPage(searchTabId)) {
+        return `Search blocked: the search engine is showing a captcha or consent page. Please open the search tab and resolve it manually, then try again.`;
+    }
+
+    const resultUrls = await extractSerpUrls(searchTabId, engine, maxResults);
+    if (resultUrls.length === 0) {
+        return `No results found for: "${query}". The search engine page may have changed its layout or the query returned no matches.`;
+    }
+
+    const summaries = [];
+    for (const url of resultUrls) {
+        const { content } = await fetchPageSummary(searchTabId, url);
+        if (content?.trim()) {
+            summaries.push(`## ${url}\n\n${content.slice(0, 2000)}`);
+        }
+    }
+
+    if (summaries.length === 0) {
+        const urlList = resultUrls.map(u => `- ${u}`).join('\n');
+        return `Found ${resultUrls.length} result(s) for "${query}" but could not extract content from any of them.\n\nURLs found:\n${urlList}`;
+    }
+
+    const engineName = getEngineConfig(engine).name;
+    console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - searchWeb complete:`, { engine: engineName, summaries: summaries.length });
+    return `# Web Search: "${query}"\nEngine: ${engineName}\n\n${summaries.join('\n\n---\n\n')}`;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Local AI helper",
     "short_name": "localAI",
-    "version": "1.29.28",
+    "version": "1.29.30",
     "options_page": "options.html",
     "permissions": [
         "activeTab",

--- a/src/options.html
+++ b/src/options.html
@@ -90,6 +90,18 @@
                   <input type="number" id="sessionRetentionDays" min="0" step="1" placeholder="Default: 2" />
                   <span>&nbsp;(in days; 0=forever)</span>
                 </div>
+                <div>
+                  <label for="searchEngine">Search Engine:</label>
+                  <select id="searchEngine">
+                    <option value="duckduckgo">DuckDuckGo</option>
+                    <option value="google">Google</option>
+                    <option value="bing">Bing</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="searchResultCount">Search Results to Visit:</label>
+                  <input type="number" id="searchResultCount" min="1" max="5" step="1" placeholder="Default: 3" />
+                </div>
               </div>
             </div>
             <!--  -->

--- a/src/options.js
+++ b/src/options.js
@@ -177,7 +177,7 @@ async function saveSettings(e) {
         for (let i = 0; i < elements.length; i++) {
             const element = elements[i];
             console.debug(`[${getLineNumber()}]: ${element?.id} is ${element?.type}`);
-            if (['select', 'checkbox', 'text', 'textarea', 'number', 'range', 'url'].indexOf(element.type) < 0) {
+            if (['select', 'select-one', 'checkbox', 'text', 'textarea', 'number', 'range', 'url'].indexOf(element.type) < 0) {
                 continue;
             }
             if(!element.id || !element.type){

--- a/tests/search-engines.test.js
+++ b/tests/search-engines.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const engineCode = fs.readFileSync(
+    path.join(__dirname, '../src/jslib/search-engines.js'),
+    'utf-8'
+);
+
+const testCode = `${engineCode}\nreturn { ENGINES, getSearchUrl, getEngineConfig };`;
+const { ENGINES, getSearchUrl, getEngineConfig } = new Function(testCode)();
+
+describe('search-engines.js', () => {
+    describe('getSearchUrl', () => {
+        it('builds a DuckDuckGo URL', () => {
+            const url = getSearchUrl('duckduckgo', 'hello world');
+            expect(url).toContain('duckduckgo.com');
+            expect(url).toContain('hello%20world');
+        });
+
+        it('builds a Google URL', () => {
+            const url = getSearchUrl('google', 'hello world');
+            expect(url).toContain('google.com/search');
+            expect(url).toContain('hello%20world');
+        });
+
+        it('builds a Bing URL', () => {
+            const url = getSearchUrl('bing', 'hello world');
+            expect(url).toContain('bing.com/search');
+            expect(url).toContain('hello%20world');
+        });
+
+        it('falls back to DuckDuckGo for unknown engine', () => {
+            const url = getSearchUrl('unknown', 'test');
+            expect(url).toContain('duckduckgo.com');
+        });
+
+        it('encodes special characters in query', () => {
+            const url = getSearchUrl('duckduckgo', 'C++ & Python');
+            expect(url).not.toContain(' ');
+            expect(url).not.toContain('+');
+            expect(url).toContain('duckduckgo.com');
+        });
+    });
+
+    describe('getEngineConfig', () => {
+        it('returns DuckDuckGo config', () => {
+            const config = getEngineConfig('duckduckgo');
+            expect(config.name).toBe('DuckDuckGo');
+            expect(config.resultSelectors).toBeInstanceOf(Array);
+            expect(config.resultSelectors.length).toBeGreaterThan(0);
+        });
+
+        it('returns Google config', () => {
+            const config = getEngineConfig('google');
+            expect(config.name).toBe('Google');
+            expect(typeof config.decodeUrl).toBe('function');
+        });
+
+        it('returns Bing config', () => {
+            const config = getEngineConfig('bing');
+            expect(config.name).toBe('Bing');
+        });
+
+        it('falls back to DuckDuckGo for unknown engine', () => {
+            const config = getEngineConfig('yahoo');
+            expect(config.name).toBe('DuckDuckGo');
+        });
+
+        it('falls back to DuckDuckGo for undefined', () => {
+            const config = getEngineConfig(undefined);
+            expect(config.name).toBe('DuckDuckGo');
+        });
+    });
+
+    describe('filterUrl — DuckDuckGo', () => {
+        const { filterUrl } = getEngineConfig('duckduckgo');
+
+        it('accepts external URLs', () => {
+            expect(filterUrl('https://example.com/article')).toBe(true);
+        });
+
+        it('rejects duckduckgo.com URLs', () => {
+            expect(filterUrl('https://duckduckgo.com/?q=test')).toBe(false);
+        });
+
+        it('rejects non-http URLs', () => {
+            expect(filterUrl('ftp://example.com')).toBe(false);
+        });
+    });
+
+    describe('filterUrl — Google', () => {
+        const { filterUrl } = getEngineConfig('google');
+
+        it('accepts external URLs', () => {
+            expect(filterUrl('https://example.com/page')).toBe(true);
+        });
+
+        it('rejects google.com URLs', () => {
+            expect(filterUrl('https://www.google.com/search?q=test')).toBe(false);
+        });
+
+        it('rejects googleapis.com URLs', () => {
+            expect(filterUrl('https://fonts.googleapis.com/css')).toBe(false);
+        });
+    });
+
+    describe('filterUrl — Bing', () => {
+        const { filterUrl } = getEngineConfig('bing');
+
+        it('accepts external URLs', () => {
+            expect(filterUrl('https://example.com/page')).toBe(true);
+        });
+
+        it('rejects bing.com URLs', () => {
+            expect(filterUrl('https://www.bing.com/search?q=test')).toBe(false);
+        });
+
+        it('rejects microsoft.com URLs', () => {
+            expect(filterUrl('https://www.microsoft.com/page')).toBe(false);
+        });
+    });
+
+    describe('decodeUrl — Google', () => {
+        const { decodeUrl } = getEngineConfig('google');
+
+        it('decodes /url?q= redirect', () => {
+            const redirect = 'https://www.google.com/url?q=https://example.com/article&sa=U';
+            expect(decodeUrl(redirect)).toBe('https://example.com/article');
+        });
+
+        it('passes through direct URLs unchanged', () => {
+            const direct = 'https://example.com/page';
+            expect(decodeUrl(direct)).toBe(direct);
+        });
+
+        it('passes through non-redirect google URLs unchanged', () => {
+            const url = 'https://www.google.com/search?q=test';
+            expect(decodeUrl(url)).toBe(url);
+        });
+    });
+});

--- a/tests/web-search.test.js
+++ b/tests/web-search.test.js
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fakeBrowser } from '@webext-core/fake-browser';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const searchEnginesCode = fs.readFileSync(
+    path.join(__dirname, '../src/jslib/search-engines.js'),
+    'utf-8'
+);
+const webSearchCode = fs.readFileSync(
+    path.join(__dirname, '../src/jslib/web-search.js'),
+    'utf-8'
+);
+
+const moduleCode = `
+    ${searchEnginesCode}
+    var DEFAULT_SEARCH_ENGINE = 'duckduckgo';
+    var DEFAULT_SEARCH_RESULT_COUNT = 3;
+    ${webSearchCode}
+    return { waitForTabLoad, extractSerpUrls, isCaptchaOrConsentPage, fetchPageSummary, searchWeb };
+`;
+
+const { waitForTabLoad, extractSerpUrls, isCaptchaOrConsentPage, fetchPageSummary, searchWeb } =
+    new Function(moduleCode)();
+
+describe('web-search.js', () => {
+    beforeEach(() => {
+        fakeBrowser.reset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    describe('waitForTabLoad', () => {
+        it('resolves when the target tab fires complete', async () => {
+            const promise = waitForTabLoad(7);
+            await fakeBrowser.tabs.onUpdated.trigger(7, { status: 'complete' }, { id: 7 });
+            await expect(promise).resolves.toBeUndefined();
+        });
+
+        it('ignores complete events from other tabs', async () => {
+            const promise = waitForTabLoad(7);
+            let resolved = false;
+            promise.then(() => { resolved = true; });
+
+            await fakeBrowser.tabs.onUpdated.trigger(99, { status: 'complete' }, { id: 99 });
+            await Promise.resolve();
+
+            expect(resolved).toBe(false);
+
+            await fakeBrowser.tabs.onUpdated.trigger(7, { status: 'complete' }, { id: 7 });
+            await promise;
+        });
+
+        it('ignores loading status events', async () => {
+            const promise = waitForTabLoad(7);
+            let resolved = false;
+            promise.then(() => { resolved = true; });
+
+            await fakeBrowser.tabs.onUpdated.trigger(7, { status: 'loading' }, { id: 7 });
+            await Promise.resolve();
+
+            expect(resolved).toBe(false);
+
+            await fakeBrowser.tabs.onUpdated.trigger(7, { status: 'complete' }, { id: 7 });
+            await promise;
+        });
+
+        it('rejects after the specified timeout', async () => {
+            vi.useFakeTimers();
+            const promise = waitForTabLoad(1, 5000);
+            const assertion = expect(promise).rejects.toThrow('Tab load timed out');
+            await vi.advanceTimersByTimeAsync(5000);
+            await assertion;
+        });
+    });
+
+    describe('isCaptchaOrConsentPage', () => {
+        beforeEach(() => {
+            vi.spyOn(chrome.scripting, 'executeScript');
+        });
+
+        it.each([
+            ['captcha',          'solve the captcha please'],
+            ['verify',           'please verify you are human'],
+            ['consent',          'cookie consent required'],
+            ['blocked',          'your request has been blocked'],
+            ['unusual traffic',  'unusual traffic from your computer network'],
+            ['robot',            'are you a robot?'],
+        ])('returns true when page title contains "%s"', async (_, title) => {
+            chrome.scripting.executeScript.mockResolvedValue([{ result: title }]);
+            expect(await isCaptchaOrConsentPage(1)).toBe(true);
+        });
+
+        it('returns false for a normal search results title', async () => {
+            chrome.scripting.executeScript.mockResolvedValue([{ result: 'best javascript frameworks 2024' }]);
+            expect(await isCaptchaOrConsentPage(1)).toBe(false);
+        });
+
+        it('returns false when executeScript throws', async () => {
+            chrome.scripting.executeScript.mockRejectedValue(new Error('scripting unavailable'));
+            expect(await isCaptchaOrConsentPage(1)).toBe(false);
+        });
+    });
+
+    describe('extractSerpUrls', () => {
+        beforeEach(() => {
+            vi.spyOn(chrome.scripting, 'executeScript');
+        });
+
+        it('filters out own-engine URLs for DuckDuckGo', async () => {
+            chrome.scripting.executeScript.mockResolvedValue([{
+                result: ['https://example.com', 'https://duckduckgo.com/?q=test']
+            }]);
+            const urls = await extractSerpUrls(1, 'duckduckgo', 5);
+            expect(urls).toEqual(['https://example.com']);
+        });
+
+        it('deduplicates results', async () => {
+            chrome.scripting.executeScript.mockResolvedValue([{
+                result: ['https://example.com', 'https://example.com', 'https://other.com']
+            }]);
+            const urls = await extractSerpUrls(1, 'duckduckgo', 5);
+            expect(urls).toEqual(['https://example.com', 'https://other.com']);
+        });
+
+        it('limits results to maxResults', async () => {
+            chrome.scripting.executeScript.mockResolvedValue([{
+                result: ['https://a.com', 'https://b.com', 'https://c.com', 'https://d.com']
+            }]);
+            const urls = await extractSerpUrls(1, 'duckduckgo', 2);
+            expect(urls).toHaveLength(2);
+        });
+
+        it('applies decodeUrl for Google redirect URLs', async () => {
+            chrome.scripting.executeScript.mockResolvedValue([{
+                result: ['https://www.google.com/url?q=https://example.com/article&sa=U']
+            }]);
+            const urls = await extractSerpUrls(1, 'google', 5);
+            expect(urls).toEqual(['https://example.com/article']);
+        });
+
+        it('filters out google.com URLs after decoding', async () => {
+            chrome.scripting.executeScript.mockResolvedValue([{
+                result: ['https://www.google.com/search?q=test', 'https://example.com']
+            }]);
+            const urls = await extractSerpUrls(1, 'google', 5);
+            expect(urls).toEqual(['https://example.com']);
+        });
+
+        it('returns an empty array when executeScript throws', async () => {
+            chrome.scripting.executeScript.mockRejectedValue(new Error('scripting unavailable'));
+            const urls = await extractSerpUrls(1, 'duckduckgo', 5);
+            expect(urls).toEqual([]);
+        });
+
+        it('passes maxResults to the injected script', async () => {
+            chrome.scripting.executeScript.mockResolvedValue([{ result: [] }]);
+            await extractSerpUrls(1, 'duckduckgo', 3);
+            const call = chrome.scripting.executeScript.mock.calls[0][0];
+            expect(call.args).toContain(3);
+        });
+    });
+
+    describe('fetchPageSummary', () => {
+        const TAB_ID = 42;
+
+        beforeEach(() => {
+            vi.spyOn(chrome.tabs, 'update').mockImplementation(async (tabId) => {
+                await fakeBrowser.tabs.onUpdated.trigger(tabId, { status: 'complete' }, { id: tabId });
+            });
+            vi.spyOn(chrome.tabs, 'sendMessage');
+        });
+
+        it('returns empty content when getMainContentOnly returns its diagnostic string', async () => {
+            chrome.tabs.sendMessage.mockResolvedValue({
+                result: 'Could not detect main content area. The page may not have semantic HTML structure. Use get_enhanced_page_content to get all content.'
+            });
+            const { url, content } = await fetchPageSummary(TAB_ID, 'https://example.com');
+            expect(url).toBe('https://example.com');
+            expect(content).toBe('');
+        });
+
+        it('returns empty content when response has an error field', async () => {
+            chrome.tabs.sendMessage.mockResolvedValue({ error: 'extraction failed' });
+            const { content } = await fetchPageSummary(TAB_ID, 'https://example.com');
+            expect(content).toBe('');
+        });
+
+        it('returns the extracted content for a valid response', async () => {
+            chrome.tabs.sendMessage.mockResolvedValue({ result: '# Article\n\nSome text here.' });
+            const { content } = await fetchPageSummary(TAB_ID, 'https://example.com');
+            expect(content).toBe('# Article\n\nSome text here.');
+        });
+
+        it('returns empty content when sendMessage rejects', async () => {
+            chrome.tabs.sendMessage.mockRejectedValue(new Error('No content script on this page'));
+            const { content } = await fetchPageSummary(TAB_ID, 'https://example.com');
+            expect(content).toBe('');
+        });
+
+        it('returns the original url alongside content', async () => {
+            chrome.tabs.sendMessage.mockResolvedValue({ result: 'some content' });
+            const { url } = await fetchPageSummary(TAB_ID, 'https://example.com/page');
+            expect(url).toBe('https://example.com/page');
+        });
+    });
+
+    describe('searchWeb', () => {
+        it('returns early for an empty query', async () => {
+            expect(await searchWeb('')).toBe('No search query provided.');
+        });
+
+        it('returns early for a whitespace-only query', async () => {
+            expect(await searchWeb('   ')).toBe('No search query provided.');
+        });
+
+        it('returns early for an undefined query', async () => {
+            expect(await searchWeb(undefined)).toBe('No search query provided.');
+        });
+    });
+});


### PR DESCRIPTION
- Added `search_web` internal tool allowing the LLM to search the web using the user's configured search engine
- Search opens a reusable background tab (visible, non-active) and reuses it across requests — tab ID persisted in `chrome.storage.session`
- Added search engine registry with URL builders, SERP CSS selectors, and URL filters/decoders for DuckDuckGo, Google, and Bing
- Added web search orchestrator handling tab lifecycle, SERP scraping, result page content extraction, captcha/consent detection, and result assembly
- Added search engine setting (default: DuckDuckGo) and search result count setting (default: 3, max: 5) to General Settings
- Fixed save settings in options page not persisting plain values