### PR TITLE
added Ollama cloud and streaming response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,34 @@
 # Local AI - Changelog
 
-## [1.29.37] - 2026-03-30 - latest
+## [1.29.45] - 2026-04-13 - latest
+
+### Models And Ollama Cloud
+
+- Added a provider-aware model catalogue backed by Ollama with cached per-model metadata
+- Added grouped local and cloud model browsing in the sidebar and options page
+- Added remembered local/cloud model-tab state in the sidebar model picker
+- Added a safe cloud fallback state instead of failing when no cloud models are available
+- Documented the signed-in local Ollama path for Ollama Cloud usage without storing API keys in the extension
+
+### Context Window
+
+- Added automatic context selection for local models when the active model exposes a context length and the user has not set it manually
+- Left cloud models on provider defaults for the first pass
+
+### Streaming
+
+- Added streamed Ollama chat response handling in the background worker
+- Added live plain-text progress in the sidebar while a reply is being generated
+- Kept the final rich markdown render as a single completion-step render
+- Kept raw streamed payloads available for debugging when debug mode is enabled
+
+### Validation
+
+- Added unit coverage for the new model catalogue, automatic context window, and streamed response helpers
+- Verified the local/cloud model browser live in Chrome
+- Verified the new streamed response behaviour live in Chrome
+
+## [1.29.37] - 2026-03-30
 
 ### Message Passing Fixes
 

--- a/Chrome/manifest.json
+++ b/Chrome/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Local AI helper",
     "short_name": "localAI",
-    "version": "1.29.37",
+    "version": "1.29.45",
     "options_page": "options.html",
     "permissions": [
         "activeTab",

--- a/Firefox/manifest.json
+++ b/Firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local AI helper",
-  "version": "1.29.37",
+  "version": "1.29.45",
   "options_page": "options.html",
   "permissions": [
     "activeTab",
@@ -14,7 +14,9 @@
   "background": {
     "scripts": [
       "jslib/constants.js",
+      "jslib/utils.js",
       "jslib/log.js",
+      "jslib/model-catalogue.js",
       "background-memory.js",
       "jslib/sessions.js",
       "jslib/session-repository.js",

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A local AI tool—these are easy to set up, usually just download and run:
 
 * [Ollama](https://ollama.com/) server is used as the API endpoint.
 
+If you use [Ollama Cloud](https://ollama.com/), the current preferred setup is still the local Ollama endpoint. Sign in with the Ollama app or CLI first, then keep the extension pointed at your local `'/api/*'` endpoint. Cloud-tagged models exposed by the signed-in local daemon can then be used without storing API keys in the extension.
+
 >[! Warning]:
 > The following API providers are deprecated for now and will only be reinstated upon request.
 > * [LM Studio](https://lmstudio.ai/) - preffered

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-ai-helper",
-  "version": "1.28.32",
+  "version": "1.29.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "local-ai-helper",
-      "version": "1.28.32",
+      "version": "1.29.45",
       "dependencies": {
         "@ankimcp/anki-mcp-server": "^0.13.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-ai-helper",
-  "version": "1.28.32",
+  "version": "1.29.45",
   "type": "module",
   "description": "Local AI helper Chrome extension",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -1,60 +1,30 @@
 
-try {
-    importScripts('jslib/constants.js');
-} catch (e) {
-    console.error('>>> Failed to load jslib/constants.js:', e);
+const backgroundRuntimeUrl = chrome.runtime?.getURL?.('') || '';
+const shouldImportBackgroundScripts = typeof importScripts === 'function' && backgroundRuntimeUrl.startsWith('chrome-extension://');
+
+function importBackgroundScript(path) {
+    if (!shouldImportBackgroundScripts) { return; }
+
+    try {
+        importScripts(path);
+    } catch (e) {
+        console.error(`>>> Failed to load ${path}:`, e);
+    }
 }
 
-try {
-    importScripts('jslib/utils.js');
-} catch (e) {
-    console.error('>>> Failed to load jslib/utils.js:', e);
-}
+importBackgroundScript('jslib/constants.js');
+importBackgroundScript('jslib/utils.js');
+importBackgroundScript('jslib/model-catalogue.js');
 
 const controllers = new Map(); // Map to manage AbortControllers per tab for concurrent fetchDataAction calls
 
-try {
-    importScripts('jslib/log.js');
-} catch (e) {
-    console.error('>>> Failed to load jslib/log.js:', e);
-}
-
-try {
-    importScripts('background-memory.js');
-} catch (e) {
-    console.error('>>> Failed to load background-memory.js:', e);
-}
-
-try {
-    importScripts('jslib/sessions.js');
-} catch (e) {
-    console.error('>>> Failed to load jslib/sessions.js:', e);
-}
-
-try {
-    importScripts('jslib/session-repository.js');
-} catch (e) {
-    console.error('>>> Failed to load jslib/session-repository.js:', e);
-}
-
-try {
-    importScripts('jslib/internal-tools.js');
-    console.debug('>>> jslib/internal-tools.js loaded successfully');
-} catch (e) {
-    console.error('>>> Failed to load jslib/internal-tools.js:', e);
-}
-
-try {
-    importScripts('jslib/search-engines.js');
-} catch (e) {
-    console.error('>>> Failed to load jslib/search-engines.js:', e);
-}
-
-try {
-    importScripts('jslib/web-search.js');
-} catch (e) {
-    console.error('>>> Failed to load jslib/web-search.js:', e);
-}
+importBackgroundScript('jslib/log.js');
+importBackgroundScript('background-memory.js');
+importBackgroundScript('jslib/sessions.js');
+importBackgroundScript('jslib/session-repository.js');
+importBackgroundScript('jslib/internal-tools.js');
+importBackgroundScript('jslib/search-engines.js');
+importBackgroundScript('jslib/web-search.js');
 
 init();
 clearLegacyPageContentStorage();
@@ -107,115 +77,107 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
     console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Tab ${activeInfo.tabId} activated`);
 });
 
+async function handleRuntimeMessage(request, sender) {
+    let response;
+    const tabId = sender?.tab?.id;
+
+    if (request.action === 'fetchData' && tabId != null) {
+        controllers.delete(tabId);
+    }
+
+    switch (request.action) {
+        case 'getTabId':
+            return { tabId: sender?.tab?.id };
+
+        case 'getModels':
+            return await getModels(request?.forceRefresh || false);
+
+        case 'fetchData':
+            return await fetchDataAction(request, sender);
+
+        case 'abortFetch':
+            if (tabId != null) {
+                const ctrl = controllers.get(tabId);
+                if (ctrl) {
+                    ctrl.abort('User aborted last request.');
+                    controllers.delete(tabId);
+                }
+            }
+            return;
+
+        case 'extractText':
+            return await convertFileToText(request.fileContent);
+
+        case "openModifiersHelpMenu":
+            chrome.tabs.create({ url: modifiersHelpUrl });
+            return;
+
+        case "openMainHelpMenu":
+            chrome.tabs.create({ url: mainHelpPageUrl });
+            return;
+
+        case "openOptionsPage":
+            chrome.tabs.create({ url: chrome.runtime.getURL('options.html') });
+            return;
+
+        case "modelCanThink":
+            response = await modelCanThink(request?.model);
+            return { canThink: response };
+
+        case "modelCanUseTools":
+            response = await modelCanUseTools(request?.model, sender?.tab);
+            return { canUseTools: response };
+
+        case "modelInfo":
+            return await getModelInfo(request?.model);
+
+        case "getModelInfo":
+            return await getModelInfo(request?.modelName, request?.forceRefresh);
+
+        case "prepareModels":
+            response = await prepareModels(request.modelName, request.unload, sender?.tab);
+            return { status: response?.status ?? 500, text: response?.statusText ?? 'Unknown error' };
+
+        case "storeImage":
+            return await storeImageHandler(request.base64, request.filename, request.mimeType);
+
+        case "deleteSessionMemory":
+            await backgroundMemory.deleteSession(request.sessionId);
+            console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Deleted session ${request.sessionId} from memory`);
+            return { status: 'success' };
+
+        case "clearAllMemory":
+            await backgroundMemory.clearAll();
+            console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Cleared all memory from IndexedDB`);
+            return { status: 'success' };
+
+        default:
+            console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Unrecognized action:`, request?.action);
+            return;
+    }
+}
+
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    (async () => {
-        try {
-            let response;
-            const tabId = sender.tab?.id;
+    const runtimeUrl = chrome.runtime.getURL('');
+    const isFirefoxRuntime = runtimeUrl.startsWith('moz-extension://');
 
-            if (request.action === 'fetchData' && tabId != null) {
-                controllers.delete(tabId);
-            }
+    if (isFirefoxRuntime) {
+        return handleRuntimeMessage(request, sender).catch(async error => {
+            console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Error handling message:`, error);
+            await dumpInFrontConsole(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Error: ${error.message}`, error, "error", sender?.tab?.id);
+            return { status: 'error', message: error.toString() };
+        });
+    }
 
-            switch (request.action) {
-                case 'getTabId':
-                    response = { tabId: sender.tab?.id };
-                    sendResponse(response);
-                    break;
-
-                case 'getModels':
-                    response = await getModels();
-                    sendResponse(response);
-                    break;
-
-                case 'fetchData':
-                    response = await fetchDataAction(request, sender);
-                    sendResponse(response);
-                    break;
-
-                case 'abortFetch':
-                    if (tabId != null) {
-                        const ctrl = controllers.get(tabId);
-                        if (ctrl) {
-                            ctrl.abort('User aborted last request.');
-                            controllers.delete(tabId);
-                        }
-                    }
-                    sendResponse();
-                    break;
-
-                case 'extractText':
-                    response = await convertFileToText(request.fileContent);
-                    sendResponse(response);
-                    break;
-
-                case "openModifiersHelpMenu":
-                    chrome.tabs.create({ url: modifiersHelpUrl });
-                    sendResponse();
-                    break;
-
-                case "openMainHelpMenu":
-                    chrome.tabs.create({ url: mainHelpPageUrl });
-                    sendResponse();
-                    break;
-
-                case "openOptionsPage":
-                    chrome.tabs.create({ url: chrome.runtime.getURL('options.html') });
-                    sendResponse();
-                    break;
-
-                case "modelCanThink":
-                    response = await modelCanThink(request?.model);
-                    sendResponse({ canThink: response });
-                    break;
-
-                case "modelCanUseTools":
-                    response = await modelCanUseTools(request?.model, sender?.tab);
-                    sendResponse({ canUseTools: response });
-                    break;
-
-                case "modelInfo":
-                    response = await getModelInfo(request?.model);
-                    sendResponse(response);
-                    break;
-
-                case "getModelInfo":
-                    response = await getModelInfo(request?.modelName, request?.forceRefresh);
-                    sendResponse(response);
-                    break;
-
-                case "prepareModels":
-                    response = await prepareModels(request.modelName, request.unload, sender.tab);
-                    sendResponse({ status: response?.status ?? 500, text: response?.statusText ?? 'Unknown error' });
-                    break;
-
-                case "storeImage":
-                    response = await storeImageHandler(request.base64, request.filename, request.mimeType);
-                    sendResponse(response);
-                    break;
-
-                case "deleteSessionMemory":
-                    await backgroundMemory.deleteSession(request.sessionId);
-                    console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Deleted session ${request.sessionId} from memory`);
-                    sendResponse({ status: 'success' });
-                    break;
-
-                case "clearAllMemory":
-                    await backgroundMemory.clearAll();
-                    console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Cleared all memory from IndexedDB`);
-                    sendResponse({ status: 'success' });
-                    break;
-
-                default:
-                    console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Unrecognized action:`, request?.action);
-                    sendResponse();
-            }
-        } catch (error) {
+    handleRuntimeMessage(request, sender)
+        .then(response => {
+            sendResponse(response);
+        })
+        .catch(async error => {
             console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Error handling message:`, error);
             await dumpInFrontConsole(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Error: ${error.message}`, error, "error", sender?.tab?.id);
             sendResponse({ status: 'error', message: error.toString() });
-        }
-    })();
+        });
 
     return true;
 });
@@ -275,6 +237,7 @@ async function init() {
         }
 
         await cleanupOrphanedSessions();
+        await refreshModelCatalogueCache();
         await validateModelInfoCache();
     } catch (e) {
         console.error(`>>> ${manifest?.name ?? ''} - Failed to initialise memory system:`, e);
@@ -382,17 +345,185 @@ function sanitizeAssistantMessageForHistory(message = {}) {
     return isMessagePersistable(sanitizedMessage) ? sanitizedMessage : null;
 }
 
+function normaliseStreamLine(rawLine = '') {
+    let line = `${rawLine || ''}`.trim();
+    if (!line) { return ''; }
+
+    line = line.replace(/^data:\s+/i, '').trim();
+    if (/^\[DONE\]$/i.test(line)) { return ''; }
+
+    return line;
+}
+
+function mergeStreamChunkBody(body = {}, chunk = {}) {
+    const mergedBody = body && typeof body === 'object' ? body : {};
+    if (!mergedBody.message || typeof mergedBody.message !== 'object') {
+        mergedBody.message = { role: 'assistant', content: '', thinking: '' };
+    }
+
+    mergedBody.model = chunk?.model || mergedBody.model || '';
+    mergedBody.created_at = chunk?.created_at || mergedBody.created_at;
+    mergedBody.done = chunk?.done ?? mergedBody.done ?? false;
+    mergedBody.done_reason = chunk?.done_reason || mergedBody.done_reason || '';
+    mergedBody.total_duration = chunk?.total_duration ?? mergedBody.total_duration;
+    mergedBody.load_duration = chunk?.load_duration ?? mergedBody.load_duration;
+    mergedBody.prompt_eval_count = chunk?.prompt_eval_count ?? mergedBody.prompt_eval_count;
+    mergedBody.prompt_eval_duration = chunk?.prompt_eval_duration ?? mergedBody.prompt_eval_duration;
+    mergedBody.eval_count = chunk?.eval_count ?? mergedBody.eval_count;
+    mergedBody.eval_duration = chunk?.eval_duration ?? mergedBody.eval_duration;
+
+    const chunkMessage = chunk?.message || {};
+    mergedBody.message.role = chunkMessage?.role || mergedBody.message.role || 'assistant';
+    mergedBody.message.content = `${mergedBody.message.content || ''}${typeof chunkMessage?.content === 'string' ? chunkMessage.content : ''}`;
+    mergedBody.message.thinking = `${mergedBody.message.thinking || ''}${typeof chunkMessage?.thinking === 'string' ? chunkMessage.thinking : ''}`;
+    if (Array.isArray(chunkMessage?.tool_calls) && chunkMessage.tool_calls.length > 0) {
+        mergedBody.message.tool_calls = chunkMessage.tool_calls;
+    }
+
+    return mergedBody;
+}
+
+function getStreamChunkUiPayload(chunk = {}, rawChunk = '') {
+    const chunkMessage = chunk?.message || {};
+
+    return {
+        model: chunk?.model || '',
+        contentDelta: typeof chunkMessage?.content === 'string' ? chunkMessage.content : '',
+        thinkingDelta: typeof chunkMessage?.thinking === 'string' ? chunkMessage.thinking : '',
+        rawChunk
+    };
+}
+
+async function sendStreamChunkToUi(senderTabId, payload = {}, debugEnabled = false) {
+    if (!senderTabId) { return; }
+
+    const hasVisibleDelta = !!((payload?.contentDelta || '') || (payload?.thinkingDelta || ''));
+    if (!hasVisibleDelta && !debugEnabled) { return; }
+
+    await chrome.tabs.sendMessage(senderTabId, {
+        action: "streamData",
+        model: payload?.model || '',
+        contentDelta: payload?.contentDelta || '',
+        thinkingDelta: payload?.thinkingDelta || '',
+        rawChunk: debugEnabled ? (payload?.rawChunk || '') : ''
+    });
+    if (chrome.runtime.lastError) { throw new Error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - chrome.runtime.lastError: ${chrome.runtime.lastError.message}`); }
+}
+
+async function consumeStreamResponse(response, senderTabId, debugEnabled = false) {
+    if (!response?.body || typeof response.body.getReader !== 'function') {
+        const responseText = await response.clone().text();
+        return {
+            responseText,
+            body: await response.json()
+        };
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let responseText = '';
+    let body = {};
+
+    while (true) {
+        const { value, done } = await reader.read();
+        buffer += decoder.decode(value || new Uint8Array(), { stream: !done });
+
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (let index = 0; index < lines.length; index++) {
+            const line = normaliseStreamLine(lines[index]);
+            if (!line) { continue; }
+
+            responseText += `${line}\n`;
+            const chunk = JSON.parse(line);
+            body = mergeStreamChunkBody(body, chunk);
+            await sendStreamChunkToUi(senderTabId, getStreamChunkUiPayload(chunk, line), debugEnabled);
+        }
+
+        if (done) { break; }
+    }
+
+    const trailingLine = normaliseStreamLine(buffer);
+    if (trailingLine) {
+        responseText += `${trailingLine}\n`;
+        const chunk = JSON.parse(trailingLine);
+        body = mergeStreamChunkBody(body, chunk);
+        await sendStreamChunkToUi(senderTabId, getStreamChunkUiPayload(chunk, trailingLine), debugEnabled);
+    }
+
+    return {
+        responseText: responseText.trim(),
+        body
+    };
+}
+
+function parsePositiveInteger(value) {
+    const parsedValue = Number(value);
+    if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+        return null;
+    }
+
+    return Math.floor(parsedValue);
+}
+
+async function getAutomaticContextWindow(modelName = '') {
+    if (!modelName) { return null; }
+
+    try {
+        const modelData = await getModelInfo(modelName);
+        if (modelData?.error) { return null; }
+        if ((modelData?.source || '').toLowerCase() === 'cloud') { return null; }
+
+        return parsePositiveInteger(modelData?.contextWindow);
+    } catch (error) {
+        console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Failed to resolve automatic context window`, error);
+        return null;
+    }
+}
+
+async function applyAutomaticModelOptions(requestData = {}, modelName = '') {
+    if (!requestData || typeof requestData !== 'object') { return requestData; }
+
+    const currentOptions = (requestData?.options && typeof requestData.options === 'object')
+        ? requestData.options
+        : {};
+    const explicitNumCtx = parsePositiveInteger(currentOptions?.num_ctx);
+    if (explicitNumCtx) {
+        currentOptions.num_ctx = explicitNumCtx;
+        requestData.options = currentOptions;
+        return requestData;
+    }
+
+    const automaticNumCtx = await getAutomaticContextWindow(modelName);
+    if (!automaticNumCtx) {
+        if (Object.keys(currentOptions).length > 0) {
+            requestData.options = currentOptions;
+        } else {
+            delete requestData.options;
+        }
+        return requestData;
+    }
+
+    currentOptions.num_ctx = automaticNumCtx;
+    requestData.options = currentOptions;
+    return requestData;
+}
+
 async function handleResponse(responseData = '', senderTabId) {
     try {
         if (!responseData) {
             await chrome.tabs.sendMessage(senderTabId, { action: "streamEnd" });
             if (chrome.runtime.lastError) { throw new Error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - chrome.runtime.lastError: ${chrome.runtime.lastError.message}`); }
+            return;
         }
 
         console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - response (type: ${typeof (responseData)})`, responseData);
-        await chrome.tabs.sendMessage(senderTabId, { action: "streamData", response: JSON.stringify(responseData) });
-        if (chrome.runtime.lastError) { throw new Error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - chrome.runtime.lastError: ${chrome.runtime.lastError.message}`); }
-        await chrome.tabs.sendMessage(senderTabId, { action: "streamEnd" });
+        await chrome.tabs.sendMessage(senderTabId, {
+            action: "streamEnd",
+            response: JSON.stringify(responseData)
+        });
         if (chrome.runtime.lastError) { throw new Error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - chrome.runtime.lastError: ${chrome.runtime.lastError.message}`); }
     } catch (error) {
         console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${error.message}`, error);
@@ -400,6 +531,20 @@ async function handleResponse(responseData = '', senderTabId) {
     }
 
     return;
+}
+
+async function handleStreamEnd(responseData = '', senderTabId, rawResponse = '', debugEnabled = false) {
+    try {
+        await chrome.tabs.sendMessage(senderTabId, {
+            action: "streamEnd",
+            response: JSON.stringify(responseData),
+            rawResponse: debugEnabled ? rawResponse : ''
+        });
+        if (chrome.runtime.lastError) { throw new Error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - chrome.runtime.lastError: ${chrome.runtime.lastError.message}`); }
+    } catch (error) {
+        console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${error.message}`, error);
+        await showUIMessage(error.message, 'error');
+    }
 }
 
 async function askAIExplanation(info, tab) {
@@ -706,8 +851,9 @@ async function fetchDataAction(request, sender) {
 
     let model = await getAiModel()
     if (model) { request.data['model'] = model; }
+    await applyAutomaticModelOptions(request.data, model);
 
-    request.data["stream"] = false;
+    request.data["stream"] = true;
     request["format"] = "json";
 
     const userInput = request?.data?.userInput || "";
@@ -787,9 +933,15 @@ async function fetchDataAction(request, sender) {
         while(true) {
             reqOpt.body = JSON.stringify(request.data);
             response = await fetch(url, reqOpt);
-            responseText = await response.clone().text();
+            if (request.data.stream && response.ok) {
+                const streamedResponse = await consumeStreamResponse(response, sender?.tab?.id, laiOptions?.debug ?? false);
+                responseText = streamedResponse.responseText;
+                body = streamedResponse.body;
+            } else {
+                responseText = await response.clone().text();
+                body = await response.json();
+            }
             console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - response received.`, responseText);
-            body = await response.json();
             responseMessage = body?.message;
             console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - response as JSON`, body);
             request.data.messages.push(responseMessage);
@@ -881,7 +1033,11 @@ async function fetchDataAction(request, sender) {
         //     await updateUIStatusBar(`Thinking completed, awaiting response...`, sender?.tab);
         //     await chrome.tabs.sendMessage(sender?.tab?.id, { action: "streamEnd" });
         // } else {
-            await handleResponse(body, sender?.tab?.id);
+            if (request.data.stream) {
+                await handleStreamEnd(body, sender?.tab?.id, responseText, laiOptions?.debug ?? false);
+            } else {
+                await handleResponse(body, sender?.tab?.id);
+            }
         // }
     }
     catch (e) {
@@ -1033,7 +1189,8 @@ async function getLaiOptions() {
         "showEmbeddedButton": false,
         "loadHistoryOnStart": false,
         "systemInstructions": 'You are a helpful assistant.',
-        "personalInfo": ''
+        "personalInfo": '',
+        "debug": false
     };
 
     try {
@@ -1098,7 +1255,7 @@ async function getCurrentTab() {
     return tab;
 }
 
-async function getModels() {
+async function getModels(forceRefresh = false) {
     const laiOptions = await getLaiOptions();
     let urlVal = laiOptions?.aiUrl;
     if (!urlVal) {
@@ -1113,18 +1270,13 @@ async function getModels() {
 
     if (urlVal.indexOf('/api/') < 0) { return; }
 
-    let response;
-    let models;
     try {
-        urlVal = new URL('/api/tags', (new URL(urlVal)).origin).href;
-        response = await fetch(urlVal, {
-            headers: {
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-        });
-
-        models = await response.json();
-        if (models.models && Array.isArray(models.models)) { return { "status": "success", "models": models.models }; }
+        const catalogue = await getModelCatalogue(urlVal, forceRefresh);
+        return {
+            "status": "success",
+            "models": catalogue?.models || [],
+            "groups": catalogue?.groups || { local: [], cloud: [] }
+        };
     } catch (e) {
         console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${e.message}`, e);
         return { "status": "error", "message": e.message };
@@ -1193,36 +1345,15 @@ async function prepareModels(modelName, remove = false, tab) {
 
 async function getModelInfo(modelName, forceRefresh = false) {
     if (!modelName) { modelName = await getAiModel(); }
-
-    if (!forceRefresh) {
-        const cached = await chrome.storage.local.get(['activeModel']);
-        if (cached?.activeModel?.modelName === modelName) {
-            return cached.activeModel;
-        }
+    const apiUrl = await getAiUrl();
+    if (!apiUrl) {
+        return { model: modelName, error: 'Missing API endpoint' };
     }
 
-    let url = await getAiUrl();
-    url = new URL(url);
-    url = `${url.protocol}//${url.host}/api/show`;
-
-    const data = { "model": modelName };
-    let res;
     try {
-        res = await fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(data)
-        });
-        const fullData = await res.json();
-
-        const { license, modelfile, template, tensors, ...cleanData } = fullData;
-        cleanData.modelName = modelName;
-
-        await chrome.storage.local.set({ activeModel: cleanData });
-
-        return cleanData;
+        return await getModelInfoFromApi(apiUrl, modelName, forceRefresh);
     } catch (err) {
-        console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${err.message}`, err, res);
+        console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${err.message}`, err);
         return { model: modelName, error: err.message };
     }
 }
@@ -1345,22 +1476,36 @@ async function validateModelInfoCache() {
     try {
         const laiOptions = await getOptions();
         const currentModel = laiOptions?.aiModel;
+        const aiUrl = laiOptions?.aiUrl;
 
-        if (!currentModel) {
+        if (!currentModel || !aiUrl) {
             console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - No active model configured`);
             return;
         }
 
-        const cached = await chrome.storage.local.get(['activeModel']);
+        const cached = await getCachedModelInfo(aiUrl, currentModel);
 
-        if (cached?.activeModel?.modelName !== currentModel) {
-            console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Model mismatch. Cached: ${cached?.activeModel?.modelName}, Current: ${currentModel}. Refreshing cache...`);
+        if (!cached?.modelName) {
+            console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Missing cached model info for ${currentModel}. Refreshing cache...`);
             await getModelInfo(currentModel, true);
         } else {
             console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Model info cache is valid for ${currentModel}`);
         }
     } catch (err) {
         console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Failed to validate model cache:`, err);
+    }
+}
+
+async function refreshModelCatalogueCache(forceRefresh = false) {
+    try {
+        const laiOptions = await getOptions();
+        const aiUrl = laiOptions?.aiUrl;
+        if (!aiUrl) { return null; }
+
+        return await getModelCatalogue(aiUrl, forceRefresh);
+    } catch (error) {
+        console.warn(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Failed to refresh model catalogue cache`, error);
+        return null;
     }
 }
 

--- a/src/css/ribbon.css
+++ b/src/css/ribbon.css
@@ -114,24 +114,58 @@
     border: 1px solid #999;
     position: absolute;
     top: 23px;
-    padding: 5px 15px;
+    padding: 5px 10px 10px;
     line-height: 25px;
     background-color: #ffe;
     z-index: 100;
     overflow-y: auto;
     height: min-content;
     max-height: 70vh;
+    min-width: 16rem;
 }
 
-.available-model-list div {
+.model-list-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 0 0.35rem;
+    margin-bottom: 0.15rem;
+    border-bottom: 1px solid #c6ba86;
+}
+
+.model-list-refresh {
+    border: 1px solid #b7aa74;
+    border-radius: 0.3rem;
+    background-color: #fffdf2;
+    color: inherit;
+    padding: 0;
+    width: 1.8rem;
+    height: 1.8rem;
+    font: inherit;
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.model-list-refresh:hover {
+    background-color: #f5edc5;
+}
+
+.model-list-item {
     padding: 5px 25px;
 }
 
-.available-model-list div:hover {
+.model-list-item:hover {
     cursor: pointer;
     background-color: #eee;
     padding: 5px 25px;
 
+}
+
+.model-list-item.unavailable,
+.model-list-item.unavailable:hover {
+    color: #666;
+    cursor: default;
+    background-color: transparent;
 }
 
 .lai-model {

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -203,6 +203,10 @@ local-ai *,
     background-color: #fff;
 }
 
+.lai-input-text.lai-stream-live {
+    white-space: pre-wrap;
+}
+
 .lai-input-label::first-letter {
     text-transform: uppercase;
 }

--- a/src/jslib/model-catalogue.js
+++ b/src/jslib/model-catalogue.js
@@ -1,0 +1,255 @@
+const modelCatalogueCacheStorageKey = 'modelCatalogueCache';
+const modelInfoCacheStorageKey = 'modelInfoCache';
+
+function getModelEndpointCacheKey(apiUrl = '') {
+    if (!apiUrl) { return ''; }
+
+    try {
+        return new URL(apiUrl).origin;
+    } catch (error) {
+        console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Invalid model endpoint`, { apiUrl, error });
+        return '';
+    }
+}
+
+function getModelSource(model = {}, sourceHint = 'local') {
+    return model?.remote_host ? 'cloud' : sourceHint;
+}
+
+function normaliseModelSummary(model = {}, sourceHint = 'local') {
+    const name = model?.name || model?.model || '';
+    const source = getModelSource(model, sourceHint);
+
+    return {
+        name,
+        model: model?.model || name,
+        source,
+        remoteHost: model?.remote_host || '',
+        remoteModel: model?.remote_model || '',
+        size: model?.size ?? null,
+        digest: model?.digest || '',
+        modifiedAt: model?.modified_at || '',
+        details: model?.details || {}
+    };
+}
+
+function sortModelsByName(models = []) {
+    return [...models].sort((left, right) => {
+        return (left?.name || '').localeCompare(right?.name || '');
+    });
+}
+
+function groupModelsBySource(models = [], sourceHint = 'local') {
+    const groups = {
+        local: [],
+        cloud: []
+    };
+
+    for (let index = 0; index < models.length; index++) {
+        const model = normaliseModelSummary(models[index], sourceHint);
+        if (!model.name) { continue; }
+        groups[model.source].push(model);
+    }
+
+    groups.local = sortModelsByName(groups.local);
+    groups.cloud = sortModelsByName(groups.cloud);
+
+    return groups;
+}
+
+function flattenModelGroups(groups = {}) {
+    return [
+        ...(groups?.local || []),
+        ...(groups?.cloud || [])
+    ];
+}
+
+function extractContextWindow(modelInfo = {}) {
+    const info = modelInfo?.model_info || {};
+
+    for (const [key, value] of Object.entries(info)) {
+        if (!/\.context_length$/i.test(key)) { continue; }
+
+        const parsedValue = Number(value);
+        if (Number.isFinite(parsedValue) && parsedValue > 0) {
+            return parsedValue;
+        }
+    }
+
+    return null;
+}
+
+function sanitiseModelInfo(fullData = {}, modelName = '', modelSummary = null) {
+    const { license, modelfile, template, tensors, ...cleanData } = fullData || {};
+
+    cleanData.modelName = modelName;
+    cleanData.contextWindow = extractContextWindow(fullData);
+    cleanData.source = modelSummary?.source || 'local';
+    cleanData.remoteHost = modelSummary?.remoteHost || '';
+    cleanData.remoteModel = modelSummary?.remoteModel || '';
+    cleanData.details = cleanData?.details || modelSummary?.details || {};
+
+    return cleanData;
+}
+
+async function readModelCatalogueCache() {
+    const stored = await chrome.storage.local.get([modelCatalogueCacheStorageKey]);
+    return stored?.[modelCatalogueCacheStorageKey] || {};
+}
+
+async function writeModelCatalogueCache(cache = {}) {
+    await chrome.storage.local.set({ [modelCatalogueCacheStorageKey]: cache });
+}
+
+async function readModelInfoCache() {
+    const stored = await chrome.storage.local.get([modelInfoCacheStorageKey]);
+    return stored?.[modelInfoCacheStorageKey] || {};
+}
+
+async function writeModelInfoCache(cache = {}) {
+    await chrome.storage.local.set({ [modelInfoCacheStorageKey]: cache });
+}
+
+async function getCachedModelCatalogue(apiUrl = '') {
+    const endpointKey = getModelEndpointCacheKey(apiUrl);
+    if (!endpointKey) { return null; }
+
+    const cache = await readModelCatalogueCache();
+    return cache?.[endpointKey] || null;
+}
+
+async function cacheModelCatalogue(apiUrl = '', catalogue = null) {
+    const endpointKey = getModelEndpointCacheKey(apiUrl);
+    if (!endpointKey || !catalogue) { return; }
+
+    const cache = await readModelCatalogueCache();
+    cache[endpointKey] = catalogue;
+    await writeModelCatalogueCache(cache);
+}
+
+async function getCachedModelInfo(apiUrl = '', modelName = '') {
+    const endpointKey = getModelEndpointCacheKey(apiUrl);
+    if (!endpointKey || !modelName) { return null; }
+
+    const cache = await readModelInfoCache();
+    return cache?.[endpointKey]?.[modelName] || null;
+}
+
+async function cacheModelInfo(apiUrl = '', modelName = '', modelInfo = null) {
+    const endpointKey = getModelEndpointCacheKey(apiUrl);
+    if (!endpointKey || !modelName || !modelInfo) { return; }
+
+    const cache = await readModelInfoCache();
+    if (!cache[endpointKey]) {
+        cache[endpointKey] = {};
+    }
+
+    cache[endpointKey][modelName] = modelInfo;
+    await writeModelInfoCache(cache);
+}
+
+async function fetchModelCataloguePayload(apiUrl = '') {
+    const endpointKey = getModelEndpointCacheKey(apiUrl);
+    if (!endpointKey) {
+        throw new Error(`Invalid API endpoint - ${apiUrl}`);
+    }
+
+    const tagsUrl = new URL('/api/tags', endpointKey).href;
+    const response = await fetch(tagsUrl, {
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8'
+        }
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to load models (${response.status}: ${response.statusText})`);
+    }
+
+    return {
+        endpoint: endpointKey,
+        payload: await response.json()
+    };
+}
+
+function buildCatalogueFromPayload(endpoint = '', payload = {}, sourceHint = 'local') {
+    const groups = groupModelsBySource(payload?.models || [], sourceHint);
+    return {
+        endpoint,
+        groups,
+        models: flattenModelGroups(groups)
+    };
+}
+
+async function fetchModelCatalogueFromApi(apiUrl = '') {
+    const endpointKey = getModelEndpointCacheKey(apiUrl);
+    if (!endpointKey) {
+        throw new Error(`Invalid API endpoint - ${apiUrl}`);
+    }
+
+    const primaryPayload = await fetchModelCataloguePayload(apiUrl);
+    const groups = groupModelsBySource(primaryPayload.payload?.models || []);
+    const catalogue = {
+        endpoint: endpointKey,
+        updatedAt: new Date().toISOString(),
+        groups,
+        models: flattenModelGroups(groups)
+    };
+
+    await cacheModelCatalogue(apiUrl, catalogue);
+
+    return catalogue;
+}
+
+async function getModelCatalogue(apiUrl = '', forceRefresh = false) {
+    if (!forceRefresh) {
+        const cached = await getCachedModelCatalogue(apiUrl);
+        if (cached?.models?.length > 0) {
+            return cached;
+        }
+    }
+
+    return fetchModelCatalogueFromApi(apiUrl);
+}
+
+async function getModelSummary(apiUrl = '', modelName = '', forceRefresh = false) {
+    if (!modelName) { return null; }
+
+    const catalogue = await getModelCatalogue(apiUrl, forceRefresh);
+    const models = catalogue?.models || [];
+
+    return models.find(model => model?.name === modelName) || null;
+}
+
+async function getModelInfoFromApi(apiUrl = '', modelName = '', forceRefresh = false) {
+    if (!modelName) {
+        throw new Error('Model name is missing');
+    }
+
+    if (!forceRefresh) {
+        const cached = await getCachedModelInfo(apiUrl, modelName);
+        if (cached) {
+            return cached;
+        }
+    }
+
+    const endpointKey = getModelEndpointCacheKey(apiUrl);
+    if (!endpointKey) {
+        throw new Error(`Invalid API endpoint - ${apiUrl}`);
+    }
+
+    const modelSummary = await getModelSummary(apiUrl, modelName, false);
+    const showUrl = new URL('/api/show', endpointKey).href;
+    const response = await fetch(showUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: modelName })
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to load model info for ${modelName} (${response.status}: ${response.statusText})`);
+    }
+    const fullData = await response.json();
+    const cleanData = sanitiseModelInfo(fullData, modelName, modelSummary);
+
+    await cacheModelInfo(apiUrl, modelName, cleanData);
+
+    return cleanData;
+}

--- a/src/jslib/ribbon.js
+++ b/src/jslib/ribbon.js
@@ -141,8 +141,7 @@ async function initRibbon() {
         updateStatusBar(`Thinking ${el.classList.contains('disabled') ? 'disabled' : 'enabled'}.`);
         setTimeout(() => { resetStatusbar(); }, 1000);
     });
-    await adjustThinkingStatus(ribbon?.querySelector('#modelThinking'));
-    await adjustToolsStatus(ribbon?.querySelector('#toolFunctions'));
+    scheduleModelCapabilityRefresh();
 
     shadowRoot?.getElementById('recycleCurrentSessionBtn')?.addEventListener('click', async e => await recycleActiveSession(e, shadowRoot), false);
     shadowRoot?.querySelector('#closeSidebarBtn')?.addEventListener('click', async e => await onCloseSidebarClick(e, shadowRoot), false);
@@ -163,12 +162,38 @@ async function initRibbon() {
 
 }
 
+function scheduleModelCapabilityRefresh(attempt = 0) {
+    if (attempt > 5) {
+        console.warn(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Model capability refresh retries exhausted.`);
+        return;
+    }
+
+    const shadowRoot = getShadowRoot();
+    const ribbon = getRibbon();
+    if (!shadowRoot || !ribbon) {
+        console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Retrying model capability refresh (${attempt + 1}/6) because the ribbon is not ready yet.`);
+        setTimeout(() => scheduleModelCapabilityRefresh(attempt + 1), 500);
+        return;
+    }
+
+    Promise.allSettled([
+        adjustThinkingStatus(ribbon?.querySelector('#modelThinking'), { suppressStatusBar: true, throwOnError: true }),
+        adjustToolsStatus(ribbon?.querySelector('#toolFunctions'), { suppressStatusBar: true, throwOnError: true })
+    ]).then(results => {
+        const failed = results.some(result => result.status === 'rejected');
+        if (!failed) { return; }
+
+        console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Retrying model capability refresh (${attempt + 1}/6) after a startup capability probe failure.`, results);
+        setTimeout(() => scheduleModelCapabilityRefresh(attempt + 1), 1000);
+    });
+}
+
 async function closeAllDropDownRibbonMenus(e) {
     const shadowRoot = getShadowRoot();
     const openMenus = Array.from(shadowRoot?.querySelectorAll('.js-menu-is-open') ?? []);
     if (openMenus.length < 1) { return; }
 
-    const compPath = e.composedPath(); // check for sidebar - if not in there, head button is clicked
+    const compPath = typeof e?.composedPath === 'function' ? e.composedPath() : []; // check for sidebar - if not in there, head button is clicked
     if (compPath?.findIndex(e => e.id === 'laiMainButton') > -1) { return; } // ext main buttono was clicked
 
     const originator = compPath?.[0]; // e?.target;
@@ -177,6 +202,8 @@ async function closeAllDropDownRibbonMenus(e) {
         console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - compPath inside forEach`, compPath);
         if (el === originator) { return; }
         if (compPath?.findIndex(p => p === el) > 0) { return; } // clicked inside the menu
+        const relatedMenuId = el?.dataset?.menuId;
+        if (relatedMenuId && compPath?.findIndex(p => p?.id === relatedMenuId) > -1) { return; }
         el?.click();
     });
 }
@@ -478,19 +505,19 @@ async function modelLabelClicked(e) {
     container.classList.remove('open', 'js-menu-is-open');
 }
 
-async function getAndShowModels() {
+async function getAndShowModels(forceRefresh = false) {
     const laiOptions = await getOptions();
     let response;
-    updateStatusBar('Loading model list...')
+    updateStatusBar(forceRefresh ? 'Refreshing model list...' : 'Loading model list...')
     try {
-        response = await chrome.runtime.sendMessage({ action: "getModels" });
+        response = await chrome.runtime.sendMessage({ action: "getModels", forceRefresh });
         if (chrome.runtime.lastError) { throw new Error(`${manifest?.name ?? ''} - [${getLineNumber()}] - chrome.runtime.lastError: ${chrome.runtime.lastError.message}`); }
         if (typeof (response) === 'boolean') { return; }
         if (!response) { throw new Error(`[${getLineNumber()}] - Server does not respond!`); }
         if (response.status !== 'success') { throw new Error(response?.message || 'Unknown error!'); }
-        laiOptions.modelList = response.models?.map(m => m.name).sort() || [];
+        laiOptions.modelList = response.models?.map(m => m.name).filter(Boolean).sort() || [];
         await setOptions(laiOptions);
-        await fillAndShowModelList(response.models?.sort((a, b) => a.name.localeCompare(b.name)));
+        await fillAndShowModelList(response.models || []);
     } catch (e) {
         showMessage(e.message, 'error');
         console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ERROR: ${e.message}`, e, response);
@@ -498,7 +525,7 @@ async function getAndShowModels() {
 
 }
 
-async function fillAndShowModelList(models) {
+async function fillAndShowModelList(models = []) {
     const shadowRoot = getShadowRoot();
     const modelList = shadowRoot.querySelector('#availableModelList');
     const modelsDropDown = shadowRoot.querySelector('#modelList');
@@ -509,21 +536,51 @@ async function fillAndShowModelList(models) {
         return;
     }
 
-    modelList.replaceChildren();
     modelsDropDown.replaceChildren();
     modelsDropDown.appendChild(opt);
     const laiOptions = await getOptions();
-    for (let idx = 0, l = models.length; idx < l; idx++) {
+    modelList.replaceChildren();
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'model-list-toolbar';
+    const refreshButton = document.createElement('button');
+    refreshButton.type = 'button';
+    refreshButton.className = 'model-list-refresh';
+    refreshButton.setAttribute('aria-label', 'Refresh the available models');
+    refreshButton.title = 'Refresh the available models';
+    refreshButton.textContent = '🗘';
+    refreshButton.addEventListener('click', async event => {
+        event.preventDefault();
+        event.stopPropagation();
+        await getAndShowModels(true);
+    });
+    toolbar.appendChild(refreshButton);
+    modelList.appendChild(toolbar);
+
+    for (let idx = 0; idx < models.length; idx++) {
         const model = models[idx];
-        const m = document.createElement('div');
-        m.textContent = `${model.name}${model.name === laiOptions.aiModel ? ' ✔' : ''}`;
-        m.addEventListener('click', async e => {
-            e.stopPropagation();
-            await closeAllDropDownRibbonMenus(e);
-            modelsDropDown.selectedIndex = idx + 1; // there is an extra empty option
-            await swapActiveModel(e, model.name);
+        const item = document.createElement('div');
+        item.className = 'model-list-item';
+        item.dataset.modelName = model?.name || '';
+        item.dataset.modelSource = model?.source || '';
+        item.textContent = `${model?.name || ''}${model?.name === laiOptions.aiModel ? ' ✔' : ''}`;
+
+        if (!model?.name) {
+            item.classList.add('unavailable');
+            modelList.appendChild(item);
+            continue;
+        }
+
+        item.addEventListener('click', async event => {
+            event.stopPropagation();
+            await closeAllDropDownRibbonMenus(event);
+            const matchingOption = Array.from(modelsDropDown.options).findIndex(option => option.value === model.name);
+            if (matchingOption > -1) {
+                modelsDropDown.selectedIndex = matchingOption;
+            }
+            await swapActiveModel(event, model.name);
         });
-        modelList.appendChild(m);
+        modelList.appendChild(item);
 
         opt = document.createElement('option');
         opt.text = opt.value = model.name;
@@ -537,7 +594,6 @@ async function fillAndShowModelList(models) {
 async function swapActiveModel(e, modelName) {
     e.stopPropagation();
     const activatedModel = e.target;
-    const parent = activatedModel.parentElement;
     const laiOptions = await getOptions();
     const oldModel = laiOptions.aiModel;
     if (!activatedModel) { return; }
@@ -572,9 +628,12 @@ async function swapActiveModel(e, modelName) {
         await adjustToolsStatus();
 
         setModelNameLabel({ "model": modelName });
-        Array.from(parent.children).forEach(child => child.textContent = child.textContent.replace(/ ✔/g, ''));
-        activatedModel.textContent = `${activatedModel.textContent} ✔`;
-        parent.classList.add('invisible');
+        const availableModelList = getShadowRoot()?.querySelector('#availableModelList');
+        availableModelList?.querySelectorAll('.model-list-item').forEach(item => {
+            const itemModelName = item.dataset.modelName || item.textContent.replace(/ ✔/g, '');
+            item.textContent = `${itemModelName}${itemModelName === modelName ? ' ✔' : ''}`;
+        });
+        availableModelList?.classList.add('invisible');
         const sideBar = getSideBar();
         sideBar.querySelector('div#modelNameContainer')?.classList.remove('open')
         showMessage(`${oldModel} model was replaced with ${modelName}.`, 'success');
@@ -735,23 +794,29 @@ function getModelModifiers() {
     return settings;
 }
 
-async function adjustThinkingStatus(thinkingIconEl) {
+async function adjustThinkingStatus(thinkingIconEl, options = {}) {
+    const suppressStatusBar = options?.suppressStatusBar || false;
+    const throwOnError = options?.throwOnError || false;
     if (!thinkingIconEl) {
         let shadowRoot = getShadowRoot();
         thinkingIconEl = shadowRoot?.querySelector('#modelThinking');
         if (!thinkingIconEl) { return; }
     }
     const model = await getAiModel();
-    if (await modelCanThinkHelper(model)) {
+    if (await modelCanThinkHelper(model, { throwOnError })) {
         thinkingIconEl.classList.remove('disabled');
     } else {
         thinkingIconEl.classList.add('disabled');
     }
-    updateStatusBar(`Thinking ${thinkingIconEl.classList.contains('disabled') ? 'disabled' : 'enabled'}.`);
-    setTimeout(() => { resetStatusbar(); }, 1000);
+    if (!suppressStatusBar) {
+        updateStatusBar(`Thinking ${thinkingIconEl.classList.contains('disabled') ? 'disabled' : 'enabled'}.`);
+        setTimeout(() => { resetStatusbar(); }, 1000);
+    }
 }
 
-async function adjustToolsStatus(el) {
+async function adjustToolsStatus(el, options = {}) {
+    const suppressStatusBar = options?.suppressStatusBar || false;
+    const throwOnError = options?.throwOnError || false;
     if (!el) {
         let shadowRoot = getShadowRoot();
         el = shadowRoot?.querySelector('#toolFunctions');
@@ -759,11 +824,13 @@ async function adjustToolsStatus(el) {
     }
 
     const model = await getAiModel();
-    if (await modelCanUseToolsHelper(model)) {
+    if (await modelCanUseToolsHelper(model, { throwOnError })) {
         el.classList.remove('disabled');
     } else {
         el.classList.add('disabled');
     }
-    updateStatusBar(`Tools ${el.classList.contains('disabled') ? 'disabled' : 'enabled'}.`);
-    setTimeout(() => { resetStatusbar(); }, 1000);
+    if (!suppressStatusBar) {
+        updateStatusBar(`Tools ${el.classList.contains('disabled') ? 'disabled' : 'enabled'}.`);
+        setTimeout(() => { resetStatusbar(); }, 1000);
+    }
 }

--- a/src/jslib/utils.js
+++ b/src/jslib/utils.js
@@ -142,35 +142,45 @@ async function getAiModel() {
     return laiOptions?.aiModel;
 }
 
-async function modelCanThinkHelper(modelName = '') {
+async function modelCanThinkHelper(modelName = '', options = {}) {
     if (!modelName) { return false; }
+    const throwOnError = options?.throwOnError || false;
 
     try {
         const response = await chrome.runtime.sendMessage({ action: 'modelCanThink', model: modelName });
         if (response?.error) {
+            if (throwOnError) {
+                throw new Error(response.error);
+            }
             console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - response error`, response?.error);
             return false;
         }
 
         return response?.canThink ?? false;
     } catch (err) {
+        if (throwOnError) { throw err; }
         console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${err.message}`, err);
         return false;
     }
 }
 
-async function modelCanUseToolsHelper(modelName = '') {
+async function modelCanUseToolsHelper(modelName = '', options = {}) {
     if (!modelName) { return false; }
+    const throwOnError = options?.throwOnError || false;
 
     try {
         const response = await chrome.runtime.sendMessage({ action: 'modelCanUseTools', model: modelName, });
         if (response?.error) {
+            if (throwOnError) {
+                throw new Error(response.error);
+            }
             console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - response error`, response?.error);
             return false;
         }
 
         return response?.canUseTools ?? false;
     } catch (err) {
+        if (throwOnError) { throw err; }
         console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${err.message}`, err);
         return false;
     }

--- a/src/lai-main.js
+++ b/src/lai-main.js
@@ -1089,8 +1089,6 @@ async function queryAI(userInput) {
         console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${e.message}`, e);
         shadowRoot?.getElementById('laiAbort')?.classList.add('invisible');
         shadowRoot?.getElementById('laiUserInput')?.classList.remove('invisible');
-    }
-    finally {
         resetStatusbar();
         shadowRoot.getElementById('laiUserInput')?.focus();
     }
@@ -1139,6 +1137,98 @@ function laiExtractDataFromResponse(response) {
 
     setModelNameLabel(response?.model ?? 'unknown');
     return fullContent || '';
+}
+
+function composeStreamingPreviewText({ thinking = '', content = '' } = {}) {
+    const blocks = [];
+    if ((thinking || '').trim().length > 0) {
+        blocks.push(`Thinking...\n${thinking}`);
+    }
+    if ((content || '').trim().length > 0) {
+        blocks.push(content);
+    }
+
+    return blocks.join('\n\n');
+}
+
+function appendStreamChunkToRecipient(recipient, response = {}) {
+    if (!recipient) { return ''; }
+
+    const contentDelta = typeof response?.contentDelta === 'string' ? response.contentDelta : '';
+    const thinkingDelta = typeof response?.thinkingDelta === 'string' ? response.thinkingDelta : '';
+    const rawChunk = typeof response?.rawChunk === 'string' ? response.rawChunk : '';
+    const accumulatedThinking = `${recipient._laiStreamThinking || ''}${thinkingDelta}`;
+    const accumulatedContent = `${recipient._laiStreamContent || ''}${contentDelta}`;
+
+    recipient._laiStreamThinking = accumulatedThinking;
+    recipient._laiStreamContent = accumulatedContent;
+    if (rawChunk) {
+        recipient._laiRawResponse = `${recipient._laiRawResponse || ''}${rawChunk}\n`;
+    }
+
+    if (response?.model) {
+        setModelNameLabel(response.model);
+    }
+
+    recipient.classList.add('lai-stream-live');
+    recipient.dataset.status = 'streaming';
+    recipient.replaceChildren();
+    recipient.textContent = composeStreamingPreviewText({
+        thinking: accumulatedThinking,
+        content: accumulatedContent
+    });
+
+    return recipient.textContent || '';
+}
+
+function resetStreamTracking(recipient, keepRawResponse = true) {
+    if (!recipient) { return; }
+
+    delete recipient._laiStreamThinking;
+    delete recipient._laiStreamContent;
+    if (!keepRawResponse) {
+        delete recipient._laiRawResponse;
+    }
+
+    recipient.classList.remove('lai-stream-live');
+    delete recipient.dataset.status;
+}
+
+function clearStreamingRecipient(recipient, keepRawResponse = true) {
+    if (!recipient) { return; }
+
+    recipient.replaceChildren();
+    resetStreamTracking(recipient, keepRawResponse);
+}
+
+async function finaliseStreamRecipient(recipient, response = {}) {
+    if (!recipient) { return; }
+
+    if (typeof response?.rawResponse === 'string' && response.rawResponse) {
+        recipient._laiRawResponse = response.rawResponse;
+        console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Raw streamed response kept for debug`, {
+            rawResponseLength: response.rawResponse.length,
+            rawResponse: response.rawResponse
+        });
+    }
+
+    const finalContent = laiExtractDataFromResponse(response);
+    clearStreamingRecipient(recipient, !!recipient._laiRawResponse);
+
+    if (!finalContent) {
+        return;
+    }
+
+    try {
+        await parseAndRender(finalContent, recipient, {
+            ...(getParseAndRenderOptions(recipient) || {}),
+            streamReply: false
+        });
+    } catch (error) {
+        recipient.textContent = finalContent;
+        laiHandleStreamActions("Streaming response render fallback", recipient);
+        throw error;
+    }
 }
 
 function createAbortHandler(controller, abortBtn, rootEl) {
@@ -1257,28 +1347,33 @@ async function messageProcessor(response, sender) {
     switch (response.action) {
         case "streamData":
 
-            let dataChunk;
             let streamDataError;
             try {
-                dataChunk = laiExtractDataFromResponse(response);
-                if (!dataChunk) { return; }
-                updateStatusBar('Receiving and processing data...');
                 const rootRecipient = laiGetRecipient();
                 if (!rootRecipient) { throw new Error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Target element not found!`) }
-                console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Starting parseAndRender`, {
+                updateStatusBar('Receiving and processing data...');
+                const previewText = appendStreamChunkToRecipient(rootRecipient, response);
+                if (!previewText) { return; }
+                scrollChatHistoryContainer({ target: rootRecipient });
+                console.debug(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Stream chunk appended`, {
                     responseAction: response.action,
-                    contentLength: dataChunk.length,
+                    contentLength: previewText.length,
                     aiCardCount: shadowRoot.querySelectorAll('.lai-ai-input').length,
                     recipientChildCount: rootRecipient.childNodes.length,
                     recipientTextLength: rootRecipient.innerText?.length ?? 0
                 });
-                await parseAndRender(dataChunk, rootRecipient, getParseAndRenderOptions(rootRecipient) || {});
             } catch (err) {
                 streamDataError = err;
-                console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${err.message}`, err, dataChunk, response);
+                console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - ${err.message}`, err, response);
             }
             break;
         case "streamEnd":
+            try {
+                await finaliseStreamRecipient(recipient, response);
+            } catch (error) {
+                console.error(`>>> ${manifest?.name ?? ''} - [${getLineNumber()}] - Failed to finalise streamed response`, error, response);
+                showMessage(`Failed to render the response as markdown - ${error.message}`, 'warning');
+            }
             break;
         case "streamError":
             laiHandleStreamActions("Stream Error", recipient);
@@ -1382,6 +1477,10 @@ function laiHandleStreamActions(logMessage, recipient, abortText = '') {
             span.textContent = abortText;
             recipient.appendChild(span);
         } else { recipient.innerHTML += `<span class="lai-aborted-text">${abortText}</span>`; }
+    }
+
+    if (recipient) {
+        resetStreamTracking(recipient);
     }
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Local AI helper",
     "short_name": "localAI",
-    "version": "1.29.37",
+    "version": "1.29.45",
     "options_page": "options.html",
     "permissions": [
         "activeTab",

--- a/src/options.js
+++ b/src/options.js
@@ -4,7 +4,9 @@ document.getElementById('pageTitle').textContent = `${manifest?.name ?? ''} - ${
 
 async function getOptions() {
     const stored = await chrome.storage.sync.get('laiOptions');
-    return stored.laiOptions || {};
+    return {
+        ...(stored.laiOptions || {})
+    };
 }
 
 document.addEventListener('DOMContentLoaded', async (e) => {
@@ -659,7 +661,6 @@ function refreshTarget(gldValues) {
 // utils
 
 async function fillModelList(models = [], selector = '') {
-    if (models.length < 1) { return; }
     if (!selector) {
         showMessage("Missing selector!", "success");
         console.error(`>>> [${getLineNumber()}] - Missing selector! ${selector || 'empty string'}`, models);
@@ -681,10 +682,18 @@ async function fillModelList(models = [], selector = '') {
         op.setAttribute('selected', 'selected');
     }
 
-    for (let i = 0; i < models.length; i++) {
+    const flatModels = Array.isArray(models)
+        ? models
+        : [
+            ...(models?.local || []),
+            ...(models?.cloud || [])
+        ];
+
+    for (let i = 0; i < flatModels.length; i++) {
         op = document.createElement('option');
-        op.value = op.text = models[i].name;
-        if (models[i].name === activeModelName) { op.setAttribute('selected', 'selected'); }
+        op.value = op.text = flatModels[i]?.name || '';
+        op.disabled = !!flatModels[i]?.unavailable || !flatModels[i]?.name;
+        if (flatModels[i]?.name === activeModelName) { op.setAttribute('selected', 'selected'); }
         modelDataList.appendChild(op);
     }
 }
@@ -936,48 +945,17 @@ function copyValue(e) {
 
 async function loadModels(e) {
     showSpinner();
-    const aiUrl = document.querySelector('#aiUrl');
-    if (!aiUrl) {
-        showMessage(`No API endpoint found - ${aiUrl?.value}!`, 'error');
-        hideSpinner();
-        return false;
-    }
-
-    const idx = aiUrl.selectedIndex >= 0 ? aiUrl.selectedIndex : 0;
-    let urlVal = aiUrl.options[idx]?.value?.trim() || '';
-    if (!urlVal) {
-        hideSpinner();
-        return;
-    }
-    if (!urlVal.startsWith('http')) {
-        showMessage(`Invalid API endpoint - ${urlVal}!`, 'error');
-        hideSpinner();
-        return false;
-    }
-
-    if (urlVal.indexOf('/api/') < 0) {
-        hideSpinner();
-        return false;
-    }
-
-    urlVal = urlVal.replace(/\/api\/.+/i, '/api/tags');
     let response;
-    let models;
     let success = false;
     try {
-        response = await fetch(urlVal, {
-            headers: {
-                'Content-Type': 'application/json; charset=utf-8',
-            },
-        });
-
-        models = await response.json();
-        if (models.models && Array.isArray(models.models)) {
-            models.models.sort((a, b) => a.name.localeCompare(b.name));
-            await fillModelList(models.models, '#aiModel');
-            await fillModelList(models.models, '#embeddingModel');
-            await fillModelList(models.models, '#titleGeneratorModel');
+        response = await chrome.runtime.sendMessage({ action: 'getModels', forceRefresh: true });
+        if (response?.status === 'success') {
+            await fillModelList(response.models, '#aiModel');
+            await fillModelList(response.models, '#embeddingModel');
+            await fillModelList(response.models, '#titleGeneratorModel');
             success = true;
+        } else {
+            throw new Error(response?.message || 'Failed to load models');
         }
     } catch (e) {
         console.error(`>>> [${getLineNumber()}] - ${e.message}`, e);

--- a/src/sidebar.html
+++ b/src/sidebar.html
@@ -2,7 +2,7 @@
 
 <header class="lai-header">
     <div class="lai-ribbon">
-        <div id="modelNameContainer" class="model-label-container ribbon-label">
+        <div id="modelNameContainer" class="model-label-container ribbon-label" data-menu-id="availableModelList">
             <div id="laiModelName" class="lai-model"></div>
             <img src="" data-type="fold">
         </div>

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -22,6 +22,13 @@ const replaceCommandPlaceholdersCode = backgroundCode.match(/function replaceCom
 const getLineNumberCode = 'function getLineNumber() { return "test:1"; }';
 const isMessagePersistableCode = utilsCode.match(/function isMessagePersistable\([\s\S]*?\n}\n/)[0];
 const sanitizeAssistantMessageForHistoryCode = backgroundCode.match(/function sanitizeAssistantMessageForHistory\([\s\S]*?\n}\n/)[0];
+const normaliseStreamLineCode = backgroundCode.match(/function normaliseStreamLine\([\s\S]*?\n}\n/)[0];
+const mergeStreamChunkBodyCode = backgroundCode.match(/function mergeStreamChunkBody\([\s\S]*?\n}\n/)[0];
+const getStreamChunkUiPayloadCode = backgroundCode.match(/function getStreamChunkUiPayload\([\s\S]*?\n}\n/)[0];
+const parsePositiveIntegerCode = backgroundCode.match(/function parsePositiveInteger\([\s\S]*?\n}\n/)[0];
+const getAutomaticContextWindowCode = backgroundCode.match(/async function getAutomaticContextWindow\([\s\S]*?\n}\n/)[0];
+const applyAutomaticModelOptionsCode = backgroundCode.match(/async function applyAutomaticModelOptions\([\s\S]*?\n}\n/)[0];
+const handleResponseCode = backgroundCode.match(/async function handleResponse\([\s\S]*?\n}\n/)[0];
 const modelCanThinkCode = backgroundCode.match(/async function modelCanThink\([\s\S]*?\n}\n/)[0];
 const modelCanUseToolsCode = backgroundCode.match(/async function modelCanUseTools\([\s\S]*?\n}\n/)[0];
 
@@ -32,15 +39,22 @@ ${replaceCommandPlaceholdersCode}
 ${getLineNumberCode}
 ${isMessagePersistableCode}
 ${sanitizeAssistantMessageForHistoryCode}
+${normaliseStreamLineCode}
+${mergeStreamChunkBodyCode}
+${getStreamChunkUiPayloadCode}
+${parsePositiveIntegerCode}
+${getAutomaticContextWindowCode}
+${applyAutomaticModelOptionsCode}
+${handleResponseCode}
 ${modelCanThinkCode}
 ${modelCanUseToolsCode}
 
-return { processTextChunk, getLastConsecutiveUserRecords, replaceCommandPlaceholders, getLineNumber, isMessagePersistable, sanitizeAssistantMessageForHistory, modelCanThink, modelCanUseTools };
+return { processTextChunk, getLastConsecutiveUserRecords, replaceCommandPlaceholders, getLineNumber, isMessagePersistable, sanitizeAssistantMessageForHistory, normaliseStreamLine, mergeStreamChunkBody, getStreamChunkUiPayload, parsePositiveInteger, getAutomaticContextWindow, applyAutomaticModelOptions, handleResponse, modelCanThink, modelCanUseTools };
 `;
 
 const executeTestFunctions = new Function(testFunctionsCode);
 
-let processTextChunk, getLastConsecutiveUserRecords, replaceCommandPlaceholders, getLineNumber, isMessagePersistable, sanitizeAssistantMessageForHistory, modelCanThink, modelCanUseTools;
+let processTextChunk, getLastConsecutiveUserRecords, replaceCommandPlaceholders, getLineNumber, isMessagePersistable, sanitizeAssistantMessageForHistory, normaliseStreamLine, mergeStreamChunkBody, getStreamChunkUiPayload, parsePositiveInteger, getAutomaticContextWindow, applyAutomaticModelOptions, handleResponse, modelCanThink, modelCanUseTools;
 
 describe('background.js', () => {
     beforeEach(() => {
@@ -51,6 +65,13 @@ describe('background.js', () => {
         getLineNumber = exports.getLineNumber;
         isMessagePersistable = exports.isMessagePersistable;
         sanitizeAssistantMessageForHistory = exports.sanitizeAssistantMessageForHistory;
+        normaliseStreamLine = exports.normaliseStreamLine;
+        mergeStreamChunkBody = exports.mergeStreamChunkBody;
+        getStreamChunkUiPayload = exports.getStreamChunkUiPayload;
+        parsePositiveInteger = exports.parsePositiveInteger;
+        getAutomaticContextWindow = exports.getAutomaticContextWindow;
+        applyAutomaticModelOptions = exports.applyAutomaticModelOptions;
+        handleResponse = exports.handleResponse;
         modelCanThink = exports.modelCanThink;
         modelCanUseTools = exports.modelCanUseTools;
     });
@@ -315,6 +336,225 @@ describe('background.js', () => {
             sanitizeAssistantMessageForHistory(message);
 
             expect(message.thinking).toBe(originalThinking);
+        });
+    });
+
+    describe('stream helpers', () => {
+        it('normalises data-prefixed lines and skips done markers', () => {
+            expect(normaliseStreamLine('data: {"a":1}')).toBe('{"a":1}');
+            expect(normaliseStreamLine('data: [DONE]')).toBe('');
+            expect(normaliseStreamLine('   ')).toBe('');
+        });
+
+        it('merges streamed content and thinking into one body', () => {
+            const merged = mergeStreamChunkBody({}, {
+                model: 'phi4:latest',
+                message: {
+                    role: 'assistant',
+                    content: 'Hello',
+                    thinking: 'Thinking'
+                },
+                done: false
+            });
+
+            const mergedAgain = mergeStreamChunkBody(merged, {
+                message: {
+                    content: ' world',
+                    thinking: ' more'
+                },
+                done: true,
+                done_reason: 'stop'
+            });
+
+            expect(mergedAgain.model).toBe('phi4:latest');
+            expect(mergedAgain.message.content).toBe('Hello world');
+            expect(mergedAgain.message.thinking).toBe('Thinking more');
+            expect(mergedAgain.done).toBe(true);
+            expect(mergedAgain.done_reason).toBe('stop');
+        });
+
+        it('builds UI payload from streamed chunk deltas', () => {
+            const payload = getStreamChunkUiPayload({
+                model: 'phi4:latest',
+                message: {
+                    content: 'Hi',
+                    thinking: 'Let me think'
+                }
+            }, '{"model":"phi4:latest"}');
+
+            expect(payload).toEqual({
+                model: 'phi4:latest',
+                contentDelta: 'Hi',
+                thinkingDelta: 'Let me think',
+                rawChunk: '{"model":"phi4:latest"}'
+            });
+        });
+    });
+
+    describe('parsePositiveInteger', () => {
+        it('returns a positive integer for integer input', () => {
+            expect(parsePositiveInteger(4096)).toBe(4096);
+        });
+
+        it('floors decimal input', () => {
+            expect(parsePositiveInteger('4096.9')).toBe(4096);
+        });
+
+        it('returns null for empty or invalid input', () => {
+            expect(parsePositiveInteger('')).toBe(null);
+            expect(parsePositiveInteger('abc')).toBe(null);
+            expect(parsePositiveInteger(0)).toBe(null);
+        });
+    });
+
+    describe('getAutomaticContextWindow', () => {
+        beforeEach(() => {
+            global.getModelInfo = vi.fn();
+            global.console = {
+                error: vi.fn()
+            };
+            global.manifest = { name: 'Test' };
+        });
+
+        it('returns local model context window when available', async () => {
+            global.getModelInfo.mockResolvedValue({
+                source: 'local',
+                contextWindow: 8192
+            });
+
+            const result = await getAutomaticContextWindow('phi4:latest');
+
+            expect(result).toBe(8192);
+        });
+
+        it('returns null for cloud models', async () => {
+            global.getModelInfo.mockResolvedValue({
+                source: 'cloud',
+                contextWindow: 131072
+            });
+
+            const result = await getAutomaticContextWindow('gpt-oss:120b-cloud');
+
+            expect(result).toBe(null);
+        });
+
+        it('returns null when model info is missing or invalid', async () => {
+            global.getModelInfo.mockResolvedValue({
+                source: 'local',
+                contextWindow: 0
+            });
+
+            const result = await getAutomaticContextWindow('broken-model');
+
+            expect(result).toBe(null);
+        });
+    });
+
+    describe('applyAutomaticModelOptions', () => {
+        beforeEach(() => {
+            global.getModelInfo = vi.fn();
+            global.console = {
+                error: vi.fn()
+            };
+            global.manifest = { name: 'Test' };
+        });
+
+        it('preserves explicitly provided num_ctx', async () => {
+            const requestData = {
+                options: {
+                    num_ctx: '2048',
+                    temperature: 0.2
+                }
+            };
+
+            const result = await applyAutomaticModelOptions(requestData, 'phi4:latest');
+
+            expect(result.options.num_ctx).toBe(2048);
+            expect(global.getModelInfo).not.toHaveBeenCalled();
+        });
+
+        it('injects automatic num_ctx for local models when absent', async () => {
+            global.getModelInfo.mockResolvedValue({
+                source: 'local',
+                contextWindow: 32768
+            });
+            const requestData = {
+                options: {
+                    temperature: 0.2
+                }
+            };
+
+            const result = await applyAutomaticModelOptions(requestData, 'phi4:latest');
+
+            expect(result.options.num_ctx).toBe(32768);
+            expect(result.options.temperature).toBe(0.2);
+        });
+
+        it('does not inject num_ctx for cloud models', async () => {
+            global.getModelInfo.mockResolvedValue({
+                source: 'cloud',
+                contextWindow: 131072
+            });
+            const requestData = {
+                options: {
+                    temperature: 0.2
+                }
+            };
+
+            const result = await applyAutomaticModelOptions(requestData, 'gpt-oss:120b-cloud');
+
+            expect(result.options.num_ctx).toBeUndefined();
+            expect(result.options.temperature).toBe(0.2);
+        });
+
+        it('leaves request data unchanged when no options are resolved', async () => {
+            global.getModelInfo.mockResolvedValue({
+                source: 'local',
+                contextWindow: null
+            });
+            const requestData = {};
+
+            const result = await applyAutomaticModelOptions(requestData, 'phi4:latest');
+
+            expect(result.options).toBeUndefined();
+        });
+    });
+
+    describe('handleResponse', () => {
+        beforeEach(() => {
+            global.chrome = {
+                runtime: {
+                    lastError: null
+                },
+                tabs: {
+                    sendMessage: vi.fn().mockResolvedValue(undefined)
+                }
+            };
+            global.showUIMessage = vi.fn();
+            global.console = {
+                debug: vi.fn(),
+                error: vi.fn()
+            };
+            global.manifest = { name: 'Test' };
+        });
+
+        it('sends a single streamEnd message with the final response payload', async () => {
+            await handleResponse({ message: { content: 'Hello' } }, 123);
+
+            expect(global.chrome.tabs.sendMessage).toHaveBeenCalledTimes(1);
+            expect(global.chrome.tabs.sendMessage).toHaveBeenCalledWith(123, {
+                action: 'streamEnd',
+                response: JSON.stringify({ message: { content: 'Hello' } })
+            });
+        });
+
+        it('sends an empty streamEnd message when no response data exists', async () => {
+            await handleResponse('', 123);
+
+            expect(global.chrome.tabs.sendMessage).toHaveBeenCalledTimes(1);
+            expect(global.chrome.tabs.sendMessage).toHaveBeenCalledWith(123, {
+                action: 'streamEnd'
+            });
         });
     });
 

--- a/tests/lai-main.test.js
+++ b/tests/lai-main.test.js
@@ -39,10 +39,10 @@ const isMessagePersistableCode = utilsCode.match(/function isMessagePersistable\
 
 // Extract the functions we want to test
 const executeLaiMainCode = new Function('document', 'window', 'manifest', 'chrome', 'isMessagePersistable',
-    isMessagePersistableCode + '\n' + laiMainCode + '; return { laiExtractDataFromResponse, isMessagePersistable };'
+    isMessagePersistableCode + '\n' + laiMainCode + '; return { laiExtractDataFromResponse, composeStreamingPreviewText, appendStreamChunkToRecipient, resetStreamTracking, clearStreamingRecipient, finaliseStreamRecipient, isMessagePersistable };'
 );
 
-let laiExtractDataFromResponse, isMessagePersistable;
+let laiExtractDataFromResponse, composeStreamingPreviewText, appendStreamChunkToRecipient, resetStreamTracking, clearStreamingRecipient, finaliseStreamRecipient, isMessagePersistable;
 
 describe('lai-main.js', () => {
     beforeEach(() => {
@@ -57,7 +57,80 @@ describe('lai-main.js', () => {
 
         const exports = executeLaiMainCode(global.document, global.window, global.manifest, global.chrome, global.isMessagePersistable);
         laiExtractDataFromResponse = exports.laiExtractDataFromResponse;
+        composeStreamingPreviewText = exports.composeStreamingPreviewText;
+        appendStreamChunkToRecipient = exports.appendStreamChunkToRecipient;
+        resetStreamTracking = exports.resetStreamTracking;
+        clearStreamingRecipient = exports.clearStreamingRecipient;
+        finaliseStreamRecipient = exports.finaliseStreamRecipient;
         isMessagePersistable = exports.isMessagePersistable;
+    });
+
+    describe('stream preview helpers', () => {
+        it('composes preview text with thinking and content blocks', () => {
+            const result = composeStreamingPreviewText({
+                thinking: 'Reasoning',
+                content: 'Answer'
+            });
+
+            expect(result).toBe('Thinking...\nReasoning\n\nAnswer');
+        });
+
+        it('appends stream chunk text to the recipient', () => {
+            const recipient = document.createElement('span');
+
+            const result = appendStreamChunkToRecipient(recipient, {
+                model: 'test-model',
+                thinkingDelta: 'Thinking',
+                contentDelta: 'Answer',
+                rawChunk: '{"message":{"content":"Answer"}}'
+            });
+
+            expect(result).toBe('Thinking...\nThinking\n\nAnswer');
+            expect(recipient.textContent).toBe(result);
+            expect(recipient.classList.contains('lai-stream-live')).toBe(true);
+            expect(recipient._laiRawResponse).toContain('"content":"Answer"');
+            expect(global.setModelNameLabel).toHaveBeenCalledWith('test-model');
+        });
+
+        it('clears temporary stream tracking without discarding raw debug data', () => {
+            const recipient = document.createElement('span');
+            recipient._laiStreamThinking = 'Thinking';
+            recipient._laiStreamContent = 'Answer';
+            recipient._laiRawResponse = '{"message":{"content":"Answer"}}';
+            recipient.dataset.status = 'streaming';
+            recipient.classList.add('lai-stream-live');
+
+            resetStreamTracking(recipient);
+
+            expect(recipient._laiStreamThinking).toBeUndefined();
+            expect(recipient._laiStreamContent).toBeUndefined();
+            expect(recipient._laiRawResponse).toContain('"content":"Answer"');
+            expect(recipient.dataset.status).toBeUndefined();
+            expect(recipient.classList.contains('lai-stream-live')).toBe(false);
+        });
+
+        it('removes live preview text when the final streamed response has no renderable content', async () => {
+            const recipient = document.createElement('span');
+            recipient.textContent = 'Thinking...\nPlanning a tool call';
+            recipient._laiStreamThinking = 'Planning a tool call';
+            recipient.dataset.status = 'streaming';
+            recipient.classList.add('lai-stream-live');
+
+            await finaliseStreamRecipient(recipient, {
+                response: JSON.stringify({
+                    model: 'thinking-model',
+                    message: {
+                        role: 'assistant',
+                        content: '',
+                        thinking: 'Planning a tool call'
+                    }
+                })
+            });
+
+            expect(recipient.textContent).toBe('');
+            expect(recipient.dataset.status).toBeUndefined();
+            expect(recipient.classList.contains('lai-stream-live')).toBe(false);
+        });
     });
 
     describe('laiExtractDataFromResponse', () => {

--- a/tests/model-catalogue.test.js
+++ b/tests/model-catalogue.test.js
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const modelCatalogueCode = fs.readFileSync(
+    path.join(__dirname, '../src/jslib/model-catalogue.js'),
+    'utf-8'
+);
+
+const executeModelCatalogueCode = new Function(
+    'chrome',
+    'fetch',
+    'manifest',
+    'getLineNumber',
+    `${modelCatalogueCode}; return {
+        getModelEndpointCacheKey,
+        getModelSource,
+        normaliseModelSummary,
+        groupModelsBySource,
+        extractContextWindow,
+        sanitiseModelInfo,
+        getCachedModelCatalogue,
+        fetchModelCatalogueFromApi,
+        getModelCatalogue,
+        getCachedModelInfo,
+        getModelInfoFromApi
+    };`
+);
+
+describe('model-catalogue.js', () => {
+    let storageState;
+    let chromeMock;
+    let fetchMock;
+    let exports;
+
+    beforeEach(() => {
+        storageState = {};
+        chromeMock = {
+            storage: {
+                local: {
+                    get: vi.fn(async (keys) => {
+                        if (Array.isArray(keys)) {
+                            return keys.reduce((accumulator, key) => {
+                                accumulator[key] = storageState[key];
+                                return accumulator;
+                            }, {});
+                        }
+
+                        if (typeof keys === 'string') {
+                            return { [keys]: storageState[keys] };
+                        }
+
+                        return { ...storageState };
+                    }),
+                    set: vi.fn(async (value) => {
+                        storageState = {
+                            ...storageState,
+                            ...value
+                        };
+                    })
+                }
+            }
+        };
+        fetchMock = vi.fn();
+
+        exports = executeModelCatalogueCode(
+            chromeMock,
+            fetchMock,
+            { name: 'Local AI helper' },
+            () => 'test:1'
+        );
+    });
+
+    it('classifies remote models as cloud summaries', () => {
+        const model = exports.normaliseModelSummary({
+            name: 'gpt-oss:120b-cloud',
+            model: 'gpt-oss:120b-cloud',
+            remote_host: 'https://ollama.com:443',
+            remote_model: 'gpt-oss:120b',
+            details: { family: 'gptoss' }
+        });
+
+        expect(model.source).toBe('cloud');
+        expect(model.remoteHost).toBe('https://ollama.com:443');
+        expect(model.remoteModel).toBe('gpt-oss:120b');
+    });
+
+    it('groups and sorts models by source', () => {
+        const groups = exports.groupModelsBySource([
+            { name: 'zeta', model: 'zeta' },
+            { name: 'beta-cloud', model: 'beta-cloud', remote_host: 'https://ollama.com:443' },
+            { name: 'alpha', model: 'alpha' }
+        ]);
+
+        expect(groups.local.map(model => model.name)).toEqual(['alpha', 'zeta']);
+        expect(groups.cloud.map(model => model.name)).toEqual(['beta-cloud']);
+    });
+
+    it('extracts context window from model info', () => {
+        const contextWindow = exports.extractContextWindow({
+            model_info: {
+                'gptoss.context_length': 131072
+            }
+        });
+
+        expect(contextWindow).toBe(131072);
+    });
+
+    it('sanitises model info and keeps catalogue metadata', () => {
+        const cleanData = exports.sanitiseModelInfo(
+            {
+                capabilities: ['thinking', 'tools'],
+                model_info: {
+                    'gptoss.context_length': 65536
+                },
+                details: {
+                    family: 'gptoss'
+                }
+            },
+            'gpt-oss:120b-cloud',
+            {
+                source: 'cloud',
+                remoteHost: 'https://ollama.com:443',
+                remoteModel: 'gpt-oss:120b'
+            }
+        );
+
+        expect(cleanData.modelName).toBe('gpt-oss:120b-cloud');
+        expect(cleanData.source).toBe('cloud');
+        expect(cleanData.contextWindow).toBe(65536);
+        expect(cleanData.remoteHost).toBe('https://ollama.com:443');
+    });
+
+    it('fetches and caches grouped model catalogue data', async () => {
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                models: [
+                    { name: 'llama3.2:latest', model: 'llama3.2:latest' },
+                    {
+                        name: 'gpt-oss:120b-cloud',
+                        model: 'gpt-oss:120b-cloud',
+                        remote_host: 'https://ollama.com:443',
+                        remote_model: 'gpt-oss:120b'
+                    }
+                ]
+            })
+        });
+
+        const catalogue = await exports.fetchModelCatalogueFromApi('http://127.0.0.1:11434/api/chat');
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(catalogue.groups.local).toHaveLength(1);
+        expect(catalogue.groups.cloud).toHaveLength(1);
+        expect(storageState.modelCatalogueCache['http://127.0.0.1:11434']).toBeDefined();
+    });
+
+    it('reuses cached catalogue data when refresh is not forced', async () => {
+        storageState.modelCatalogueCache = {
+            'http://127.0.0.1:11434': {
+                endpoint: 'http://127.0.0.1:11434',
+                updatedAt: '2026-04-13T00:00:00.000Z',
+                groups: {
+                    local: [{ name: 'llama3.2:latest', model: 'llama3.2:latest', source: 'local' }],
+                    cloud: []
+                },
+                models: [{ name: 'llama3.2:latest', model: 'llama3.2:latest', source: 'local' }]
+            }
+        };
+
+        const catalogue = await exports.getModelCatalogue('http://127.0.0.1:11434/api/chat');
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(catalogue.models[0].name).toBe('llama3.2:latest');
+    });
+
+    it('loads model info, enriches it, and caches it by endpoint and name', async () => {
+        storageState.modelCatalogueCache = {
+            'http://127.0.0.1:11434': {
+                endpoint: 'http://127.0.0.1:11434',
+                updatedAt: '2026-04-13T00:00:00.000Z',
+                groups: {
+                    local: [],
+                    cloud: [{
+                        name: 'gpt-oss:120b-cloud',
+                        model: 'gpt-oss:120b-cloud',
+                        source: 'cloud',
+                        remoteHost: 'https://ollama.com:443',
+                        remoteModel: 'gpt-oss:120b'
+                    }]
+                },
+                models: [{
+                    name: 'gpt-oss:120b-cloud',
+                    model: 'gpt-oss:120b-cloud',
+                    source: 'cloud',
+                    remoteHost: 'https://ollama.com:443',
+                    remoteModel: 'gpt-oss:120b'
+                }]
+            }
+        };
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                capabilities: ['completion', 'tools', 'thinking'],
+                model_info: {
+                    'gptoss.context_length': 131072
+                },
+                details: {
+                    family: 'gptoss'
+                }
+            })
+        });
+
+        const modelInfo = await exports.getModelInfoFromApi(
+            'http://127.0.0.1:11434/api/chat',
+            'gpt-oss:120b-cloud'
+        );
+
+        expect(modelInfo.modelName).toBe('gpt-oss:120b-cloud');
+        expect(modelInfo.source).toBe('cloud');
+        expect(modelInfo.contextWindow).toBe(131072);
+        expect(storageState.modelInfoCache['http://127.0.0.1:11434']['gpt-oss:120b-cloud']).toBeDefined();
+    });
+});

--- a/tests/ribbon.test.js
+++ b/tests/ribbon.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { JSDOM } from 'jsdom';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ribbonCode = fs.readFileSync(
+    path.join(__dirname, '../src/jslib/ribbon.js'),
+    'utf-8'
+);
+
+const closeAllDropDownRibbonMenusCode = ribbonCode.match(/async function closeAllDropDownRibbonMenus\([\s\S]*?\n}\n/)[0];
+const fillAndShowModelListCode = ribbonCode.match(/async function fillAndShowModelList\([\s\S]*?\n}\n/)[0];
+
+const executeRibbonCode = new Function(
+    'document',
+    'getShadowRoot',
+    'getOptions',
+    'showMessage',
+    'manifest',
+    'getLineNumber',
+    'closeAllDropDownRibbonMenus',
+    'swapActiveModel',
+    'getAndShowModels',
+    `
+${closeAllDropDownRibbonMenusCode}
+${fillAndShowModelListCode}
+
+return { closeAllDropDownRibbonMenus, fillAndShowModelList };
+`
+);
+
+describe('ribbon.js model list', () => {
+    let document;
+    let getShadowRoot;
+    let getOptions;
+    let showMessage;
+    let getLineNumber;
+    let closeAllDropDownRibbonMenus;
+    let swapActiveModel;
+    let getAndShowModels;
+    let exports;
+
+    beforeEach(() => {
+        const dom = new JSDOM(`
+            <!DOCTYPE html>
+            <html>
+                <body>
+                    <div id="shadowRoot">
+                        <div id="availableModelList" class="available-model-list invisible"></div>
+                        <select id="modelList">
+                            <option value="">Select Model name</option>
+                        </select>
+                    </div>
+                </body>
+            </html>
+        `);
+
+        document = dom.window.document;
+        getShadowRoot = vi.fn(() => document.getElementById('shadowRoot'));
+        getOptions = vi.fn(async () => ({ aiModel: 'llama3.2' }));
+        showMessage = vi.fn();
+        getLineNumber = vi.fn(() => 'test:1');
+        closeAllDropDownRibbonMenus = vi.fn(async () => undefined);
+        swapActiveModel = vi.fn(async () => undefined);
+        getAndShowModels = vi.fn(async () => undefined);
+
+        exports = executeRibbonCode(
+            document,
+            getShadowRoot,
+            getOptions,
+            showMessage,
+            { name: 'Local AI helper' },
+            getLineNumber,
+            closeAllDropDownRibbonMenus,
+            swapActiveModel,
+            getAndShowModels
+        );
+    });
+
+    it('keeps the model dropdown open when clicking inside its related panel', async () => {
+        const shadowRoot = getShadowRoot();
+        const modelNameContainer = document.createElement('div');
+        modelNameContainer.id = 'modelNameContainer';
+        modelNameContainer.dataset.menuId = 'availableModelList';
+        modelNameContainer.classList.add('js-menu-is-open');
+        modelNameContainer.click = vi.fn();
+        shadowRoot.appendChild(modelNameContainer);
+
+        const availableModelList = shadowRoot.querySelector('#availableModelList');
+        const item = document.createElement('button');
+        availableModelList.appendChild(item);
+
+        await exports.closeAllDropDownRibbonMenus({
+            composedPath: () => [item, availableModelList, shadowRoot]
+        });
+
+        expect(modelNameContainer.click).not.toHaveBeenCalled();
+    });
+
+    it('closes the open menu when clicking outside the related panel', async () => {
+        const shadowRoot = getShadowRoot();
+        const modelNameContainer = document.createElement('div');
+        modelNameContainer.id = 'modelNameContainer';
+        modelNameContainer.dataset.menuId = 'availableModelList';
+        modelNameContainer.classList.add('js-menu-is-open');
+        modelNameContainer.click = vi.fn();
+        shadowRoot.appendChild(modelNameContainer);
+
+        const outsideElement = document.createElement('div');
+
+        await exports.closeAllDropDownRibbonMenus({
+            composedPath: () => [outsideElement, shadowRoot]
+        });
+
+        expect(modelNameContainer.click).toHaveBeenCalledOnce();
+    });
+
+    it('renders a single model list with a refresh control', async () => {
+        await exports.fillAndShowModelList([
+            { name: 'llama3.2', source: 'local' },
+            { name: 'gpt-oss:120b-cloud', source: 'cloud' }
+        ]);
+
+        const shadowRoot = getShadowRoot();
+        const modelList = shadowRoot.querySelector('#availableModelList');
+        const refreshButton = modelList.querySelector('.model-list-refresh');
+        const items = Array.from(modelList.querySelectorAll('.model-list-item'));
+
+        expect(refreshButton).not.toBeNull();
+        expect(items.map(item => item.dataset.modelName)).toEqual(['llama3.2', 'gpt-oss:120b-cloud']);
+        expect(modelList.classList.contains('invisible')).toBe(false);
+    });
+
+    it('refreshes the model catalogue on demand', async () => {
+        await exports.fillAndShowModelList([
+            { name: 'llama3.2', source: 'local' }
+        ]);
+
+        const refreshButton = getShadowRoot().querySelector('.model-list-refresh');
+
+        await refreshButton.dispatchEvent(
+            new document.defaultView.MouseEvent('click', { bubbles: true })
+        );
+
+        expect(getAndShowModels).toHaveBeenCalledWith(true);
+    });
+
+    it('selects a model item through swapActiveModel', async () => {
+        await exports.fillAndShowModelList([
+            { name: 'llama3.2', source: 'local' },
+            { name: 'gpt-oss:120b-cloud', source: 'cloud' }
+        ]);
+
+        const cloudItem = Array.from(getShadowRoot().querySelectorAll('.model-list-item'))
+            .find(item => item.dataset.modelName === 'gpt-oss:120b-cloud');
+
+        await cloudItem.dispatchEvent(
+            new document.defaultView.MouseEvent('click', { bubbles: true })
+        );
+
+        expect(swapActiveModel).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION

### Models And Ollama Cloud

- Added a provider-aware model catalogue backed by Ollama with cached per-model metadata
- Added grouped local and cloud model browsing in the sidebar and options page
- Added remembered local/cloud model-tab state in the sidebar model picker
- Added a safe cloud fallback state instead of failing when no cloud models are available
- Documented the signed-in local Ollama path for Ollama Cloud usage without storing API keys in the extension

### Context Window

- Added automatic context selection for local models when the active model exposes a context length and the user has not set it manually
- Left cloud models on provider defaults for the first pass

### Streaming

- Added streamed Ollama chat response handling in the background worker
- Added live plain-text progress in the sidebar while a reply is being generated
- Kept the final rich markdown render as a single completion-step render
- Kept raw streamed payloads available for debugging when debug mode is enabled

### Validation

- Added unit coverage for the new model catalogue, automatic context window, and streamed response helpers
- Verified the local/cloud model browser live in Chrome
- Verified the new streamed response behaviour live in Chrome